### PR TITLE
FYI: Pulling from upstream commits is not necessarily safe 

### DIFF
--- a/.github/workflows/sync-and-release.yml
+++ b/.github/workflows/sync-and-release.yml
@@ -1,0 +1,204 @@
+name: Sync upstream and release
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      force_release:
+        description: 'Build and release even if ost already includes the latest upstream tag'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  sync-and-release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout ost
+        uses: actions/checkout@v4
+        with:
+          ref: ost
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure git
+        shell: bash
+        run: |
+          git config user.email "[email protected]"
+          git config user.name "CloudRedirect Fork Bot"
+          git config rerere.enabled true
+          git config rerere.autoupdate true
+
+      - name: Restore rerere cache
+        uses: actions/cache@v4
+        with:
+          path: .git/rr-cache
+          key: rerere-${{ github.run_id }}
+          restore-keys: |
+            rerere-
+
+      - name: Add upstream remote and fetch
+        shell: bash
+        run: |
+          git remote add upstream https://github.com/Selectively11/CloudRedirect.git
+          git fetch upstream --tags
+
+      - name: Pick upstream tag and compute release tag
+        id: tag
+        shell: bash
+        run: |
+          set -eo pipefail
+          upstream_tag=$(git -c versionsort.suffix=- tag -l --sort=-v:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
+          if [ -z "$upstream_tag" ]; then
+            echo "no upstream stable tag found"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "upstream_tag=$upstream_tag" >> "$GITHUB_OUTPUT"
+
+          tag_commit=$(git rev-parse "${upstream_tag}^{commit}")
+          merge_base=$(git merge-base ost "$tag_commit" 2>/dev/null || true)
+          force='${{ github.event.inputs.force_release }}'
+          if [ "$merge_base" = "$tag_commit" ] && [ "$force" != "true" ]; then
+            echo "ost already includes $upstream_tag — nothing to do"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base=${upstream_tag#v}
+          rev=0
+          for existing in $(git tag -l "v${base}.*"); do
+            n=${existing##*.}
+            if [[ "$n" =~ ^[0-9]+$ ]] && [ "$n" -ge "$rev" ]; then
+              rev=$((n+1))
+            fi
+          done
+          [ "$rev" -eq 0 ] && rev=1
+          echo "release_tag=v${base}.${rev}" >> "$GITHUB_OUTPUT"
+          echo "release_version=${base}.${rev}" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+
+      - name: Rebase ost onto upstream tag
+        id: rebase
+        if: steps.tag.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          if ! git rebase "${{ steps.tag.outputs.upstream_tag }}"; then
+            git rebase --abort || true
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Open or update conflict issue
+        if: failure() && steps.rebase.outputs.conflict == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const upstreamTag = '${{ steps.tag.outputs.upstream_tag }}';
+            const title = `Rebase conflict on upstream ${upstreamTag}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `Automatic rebase of \`ost\` onto upstream tag \`${upstreamTag}\` failed.`,
+              ``,
+              `Failed run: ${runUrl}`,
+              ``,
+              `To resolve locally:`,
+              '```',
+              `git fetch upstream`,
+              `git checkout ost`,
+              `git rebase ${upstreamTag}`,
+              `# resolve conflicts, then`,
+              `git rebase --continue`,
+              `git push origin ost --force-with-lease`,
+              '```',
+            ].join('\n');
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'rebase-conflict',
+            });
+            const existing = issues.data.find(i => i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Rebase still failing in run ${context.runId} (${runUrl}).`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['rebase-conflict'],
+              });
+            }
+
+      - name: Patch Version.props (not committed)
+        if: steps.tag.outputs.should_release == 'true'
+        shell: pwsh
+        run: |
+          $version = '${{ steps.tag.outputs.release_version }}'
+          $content = Get-Content Version.props -Raw
+          $content = $content -replace '<ReleaseVersion>[^<]+</ReleaseVersion>', "<ReleaseVersion>$version</ReleaseVersion>"
+          Set-Content Version.props -Value $content -NoNewline
+
+      - name: Setup .NET
+        if: steps.tag.outputs.should_release == 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Configure CMake (Visual Studio 17 2022, x64)
+        if: steps.tag.outputs.should_release == 'true'
+        run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+
+      - name: Build native targets
+        if: steps.tag.outputs.should_release == 'true'
+        run: cmake --build build --config Release --target cloud_redirect cr_loader cloud_redirect_cli
+
+      - name: Publish launcher
+        if: steps.tag.outputs.should_release == 'true'
+        run: dotnet publish ui/CloudRedirect.csproj -c Release -r win-x64 --self-contained false -o ui/bin/publish
+
+      - name: Compute CloudRedirect.exe SHA256
+        if: steps.tag.outputs.should_release == 'true'
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash -Algorithm SHA256 ui/bin/publish/CloudRedirect.exe).Hash.ToLower()
+          Set-Content -Path ui/bin/publish/CloudRedirect.exe.sha256 -Value $hash -NoNewline
+
+      - name: Push rebased ost
+        if: steps.tag.outputs.should_release == 'true'
+        shell: bash
+        run: git push origin ost --force-with-lease
+
+      - name: Mirror upstream master to fork master
+        if: steps.tag.outputs.should_release == 'true'
+        shell: bash
+        run: git push origin "refs/remotes/upstream/master:refs/heads/master"
+
+      - name: Create GitHub release
+        if: steps.tag.outputs.should_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.release_tag }}
+          name: ${{ steps.tag.outputs.release_tag }}
+          target_commitish: ost
+          body: |
+            Built from upstream `${{ steps.tag.outputs.upstream_tag }}` with OpenSteamTool support layered on top.
+
+            See [upstream release notes](https://github.com/Selectively11/CloudRedirect/releases/tag/${{ steps.tag.outputs.upstream_tag }}).
+          files: |
+            ui/bin/publish/CloudRedirect.exe
+            ui/bin/publish/CloudRedirect.exe.sha256
+            build/Release/cloud_redirect.dll
+            build/Release/cr_loader.dll

--- a/.github/workflows/sync-and-release.yml
+++ b/.github/workflows/sync-and-release.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Configure git
         shell: bash
         run: |
-          git config user.email "[email protected]"
-          git config user.name "CloudRedirect Fork Bot"
+          git config user.email "65749353+JanitorialMess@users.noreply.github.com"
+          git config user.name "JanitorialMess"
           git config rerere.enabled true
           git config rerere.autoupdate true
 
@@ -62,24 +62,25 @@ jobs:
           fi
           echo "upstream_tag=$upstream_tag" >> "$GITHUB_OUTPUT"
 
-          tag_commit=$(git rev-parse "${upstream_tag}^{commit}")
-          merge_base=$(git merge-base ost "$tag_commit" 2>/dev/null || true)
+          base=${upstream_tag#v}
+          rev=0
+          existing_rev=-1
+          for existing in $(git tag -l "v${base}.*"); do
+            n=${existing##*.}
+            if [[ "$n" =~ ^[0-9]+$ ]]; then
+              if [ "$n" -ge "$rev" ]; then rev=$((n+1)); fi
+              if [ "$n" -gt "$existing_rev" ]; then existing_rev=$n; fi
+            fi
+          done
+          [ "$rev" -eq 0 ] && rev=1
+
           force='${{ github.event.inputs.force_release }}'
-          if [ "$merge_base" = "$tag_commit" ] && [ "$force" != "true" ]; then
-            echo "ost already includes $upstream_tag — nothing to do"
+          if [ "$existing_rev" -ge 0 ] && [ "$force" != "true" ]; then
+            echo "fork already has a v${base}.* release — nothing to do"
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          base=${upstream_tag#v}
-          rev=0
-          for existing in $(git tag -l "v${base}.*"); do
-            n=${existing##*.}
-            if [[ "$n" =~ ^[0-9]+$ ]] && [ "$n" -ge "$rev" ]; then
-              rev=$((n+1))
-            fi
-          done
-          [ "$rev" -eq 0 ] && rev=1
           echo "release_tag=v${base}.${rev}" >> "$GITHUB_OUTPUT"
           echo "release_version=${base}.${rev}" >> "$GITHUB_OUTPUT"
           echo "should_release=true" >> "$GITHUB_OUTPUT"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,18 @@ if(WIN32)
     target_link_libraries(cloud_redirect_cli PRIVATE Shell32 Ole32)
     # Ensure DLL is built before CLI
     add_dependencies(cloud_redirect_cli cloud_redirect)
+
+    # CloudRedirect loader stub for OpenSteamTool. Installed in Steam folder
+    # as cr_loader.dll. OST's hijack DLLs are string-patched to load this
+    # filename instead of OpenSteamTool.dll, so the real OST stays at its
+    # natural filename and the stub loads OST + CR side by side.
+    add_library(cr_loader SHARED
+        src/platform/win/ost_chainloader.cpp
+    )
+    set_target_properties(cr_loader PROPERTIES
+        PREFIX ""
+        OUTPUT_NAME "cr_loader"
+    )
 else()
     target_include_directories(cloud_redirect PRIVATE src/platform/linux)
     target_link_libraries(cloud_redirect PRIVATE dl pthread)

--- a/src/platform/win/cloud_intercept.cpp
+++ b/src/platform/win/cloud_intercept.cpp
@@ -3277,7 +3277,7 @@ static void TryAutoUpdateDll() {
     }
 
     HINTERNET hReq = WinHttpOpenRequest(hConn, L"GET",
-        L"/repos/Selectively11/CloudRedirect/releases",
+        L"/repos/JanitorialMess/CloudRedirect/releases",
         nullptr, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES,
         WINHTTP_FLAG_SECURE);
     if (!hReq) {

--- a/src/platform/win/cloud_intercept.cpp
+++ b/src/platform/win/cloud_intercept.cpp
@@ -105,6 +105,10 @@ static constexpr uint32_t ENGINE_OFF_GLOBAL_HANDLE   = 3144;  // uint32_t: globa
 static constexpr uint32_t ENGINE_OFF_USER_MAP        = 3296;  // CUtlSortedVector: user map
 // CCMInterface layout offsets
 static constexpr uint32_t CCM_OFF_CONN_CONTEXT       = 1688;  // connection context pointer
+static constexpr uint32_t CCM_OFF_STEAMID            = 500;   // m_SteamID (CSteamID, 8 bytes);
+                                                              // per IDA decompile of sub_1385B0060
+                                                              // (CCMInterface::SetSteamID):
+                                                              // `*(_QWORD *)(this + 500) = newSid`
 // CUtlSortedVector layout (at engine + ENGINE_OFF_USER_MAP)
 //   +0: QWORD array_base_ptr  (points to array of 16-byte entries)
 //  +16: DWORD count
@@ -248,7 +252,19 @@ static LONG WINAPI CrashExcFilter(PEXCEPTION_POINTERS pExc) {
 
 
 static uintptr_t g_payloadBase = 0;
-static uintptr_t g_steamClientBase = 0;           // steamclient64.dll base address
+// Base address used for all RVA-derived lookups. Under OpenSteamTool this is
+// diversion.dll's base, not steamclient64.dll's -- OST copies steamclient64.dll
+// to bin/diversion.dll, loads that copy, and Steam's live user/CM state lives
+// in diversion's separate mapping. See ResolveSteamClientOrDiversion below.
+static uintptr_t g_steamClientBase = 0;
+
+// Prefer diversion.dll's base when OpenSteamTool is loaded; fall back to
+// steamclient64.dll for the SteamTools / no-unlocker case.
+static uintptr_t ResolveSteamClientOrDiversion() {
+    if (HMODULE hDiv = GetModuleHandleA("diversion.dll")) return (uintptr_t)hDiv;
+    if (HMODULE hSC  = GetModuleHandleA("steamclient64.dll")) return (uintptr_t)hSC;
+    return 0;
+}
 static std::string g_steamPath;
 static RecvPktFn g_originalRecvPkt = nullptr;
 static void** g_recvPktSlot = nullptr;            // address of the patched RecvPkt vtable slot, for shutdown restore
@@ -363,12 +379,11 @@ static uintptr_t FindCurrentUser();
 
 static uintptr_t ResolveCurrentUserForRestore(const char* featureTag, uint32_t appId) {
     if (!g_steamClientBase) {
-        HMODULE hSC = GetModuleHandleA("steamclient64.dll");
-        if (!hSC) {
-            LOG("[%s] In-memory restore skipped for app %u: steamclient64.dll not loaded", featureTag, appId);
+        g_steamClientBase = ResolveSteamClientOrDiversion();
+        if (!g_steamClientBase) {
+            LOG("[%s] In-memory restore skipped for app %u: neither diversion.dll nor steamclient64.dll loaded", featureTag, appId);
             return 0;
         }
-        g_steamClientBase = (uintptr_t)hSC;
     }
 
     uintptr_t userPtr = 0;
@@ -384,9 +399,8 @@ static uintptr_t ResolveCurrentUserForRestore(const char* featureTag, uint32_t a
 
 static uintptr_t FindCurrentUser() {
     if (!g_steamClientBase) {
-        HMODULE hSC = GetModuleHandleA("steamclient64.dll");
-        if (!hSC) return 0;
-        g_steamClientBase = (uintptr_t)hSC;
+        g_steamClientBase = ResolveSteamClientOrDiversion();
+        if (!g_steamClientBase) return 0;
     }
 
     uintptr_t* pEngineGlobal = (uintptr_t*)(g_steamClientBase + SC_RVA_GLOBAL_ENGINE);
@@ -756,6 +770,31 @@ static void TryFindCCMInterface() {
             CCM_OFF_CONN_CONTEXT, *(void**)((uintptr_t)ccm + CCM_OFF_CONN_CONTEXT));
     } __except(EXCEPTION_EXECUTE_HANDLER) {
         LOG("[CCM] WARNING: exception during extended diagnostics (code=0x%lX)", GetExceptionCode());
+    }
+
+    // Seed g_steamId from CCMInterface+m_SteamID. Required under OpenSteamTool:
+    // the per-packet capture path in OnSendPkt rarely fires (no ST code cave),
+    // and the vtable hook's request-header parse fails silently on OST's wire
+    // layout, so without this CR times out waiting for SteamID and falls back
+    // to safe-no-op for every Cloud RPC.
+    if (g_steamId.load() == 0) {
+        __try {
+            uint64_t sid = *(uint64_t*)((uintptr_t)ccm + CCM_OFF_STEAMID);
+            if (sid != 0) {
+                g_steamId.store(sid);
+                uint32_t aid = GetAccountId();
+                LOG("[CCM]   Captured SteamID from CCMInterface+%u: %llu (accountId=%u)",
+                    CCM_OFF_STEAMID, (unsigned long long)sid, aid);
+                HttpServer::SetAccountId(aid);
+                ScheduleStartupMetadataSync();
+            } else {
+                LOG("[CCM]   CCMInterface+%u m_SteamID is 0 (user not yet authenticated?)",
+                    CCM_OFF_STEAMID);
+            }
+        } __except(EXCEPTION_EXECUTE_HANDLER) {
+            LOG("[CCM]   SEH reading m_SteamID at CCMInterface+%u (code=0x%lX)",
+                CCM_OFF_STEAMID, GetExceptionCode());
+        }
     }
 
     // Install service-method vtable hook (Approach E) now that we have steamclient base
@@ -1315,6 +1354,12 @@ static bool __fastcall ServiceMethodHook(void* thisptr, const char* methodName,
     if (strncmp(methodName, "Cloud.", 6) != 0) {
         return g_originalSlot5(thisptr, methodName, request, response, flags);
     }
+
+    // Retry CCMInterface discovery on each Cloud RPC. Under OST the eager
+    // install at Init() runs before Steam has populated engine.userMap, so
+    // the one-shot TryFindCCMInterface in OnSendPkt misses. Idempotent fast
+    // path (atomic-load + return) once found.
+    TryFindCCMInterface();
 
     // Check if it's a Cloud RPC we handle (zero-alloc check via strcmp)
     // Request/response RPCs only - notifications go through slots 7/8
@@ -3621,6 +3666,29 @@ void Init(const std::string& steamPath) {
 
     if (HasNamespaceApps()) {
         LOG("[NS] Namespace mode ENABLED: %d self-unlocking of %d total lua(s)", selfUnlocking, totalLuas);
+
+        // Install the vtable hook eagerly. Under OpenSteamTool the CSteamEngine
+        // userMap that TryFindCCMInterface walks stays empty in steamclient64
+        // (Steam's live state is in diversion.dll instead), so the lazy install
+        // path in OnSendPkt never fires. InstallServiceMethodHook only needs
+        // g_steamClientBase + HasNamespaceApps and is idempotent, so calling
+        // it here is safe in both ST and OST modes.
+        if (!g_steamClientBase) {
+            g_steamClientBase = ResolveSteamClientOrDiversion();
+            if (g_steamClientBase) {
+                bool isDiv = (GetModuleHandleA("diversion.dll") == (HMODULE)g_steamClientBase);
+                LOG("[VtHook] Resolved %s @ %p as steamclient base%s",
+                    isDiv ? "diversion.dll" : "steamclient64.dll",
+                    (void*)g_steamClientBase,
+                    isDiv ? " (OST integration mode)" : "");
+            }
+        }
+        if (g_steamClientBase) {
+            LOG("[VtHook] Eager install from Init (no CCMInterface dependency)");
+            InstallServiceMethodHook();
+        } else {
+            LOG("[VtHook] Eager install skipped: neither diversion.dll nor steamclient64.dll loaded yet");
+        }
     } else {
         LOG("[NS] No self-unlocking Lua files found (%d total luas) -- DLL will only log Cloud RPCs", totalLuas);
     }
@@ -4451,11 +4519,13 @@ static void ShutdownImpl() {
     // Also skip if hook drain timed out — restoring slots with hooks in-flight
     // risks control-flow corruption.
     if (!hookDrainTimedOut && g_vtableHookInstalled.load(std::memory_order_acquire) && g_steamClientBase) {
-        HMODULE currentSC = GetModuleHandleA("steamclient64.dll");
-        if (!currentSC) {
-            LOG("Shutdown: steamclient64.dll already unloaded, skipping vtable restore");
+        // Re-resolve via the same helper used at install time so we compare against the
+        // module CR actually patched (diversion.dll under OST, steamclient64.dll otherwise).
+        uintptr_t currentBase = ResolveSteamClientOrDiversion();
+        if (!currentBase) {
+            LOG("Shutdown: neither diversion.dll nor steamclient64.dll loaded, skipping vtable restore");
             g_vtableHookInstalled.store(false, std::memory_order_release);
-            // steamclient gone: cached EAs point into unmapped memory; clear so a
+            // Module gone: cached EAs point into unmapped memory; clear so a
             // subsequent re-init re-resolves against the new module image.
             g_serviceTransportVtableEa = 0;
             g_originalSlot4 = nullptr;
@@ -4465,9 +4535,9 @@ static void ShutdownImpl() {
             g_parseFromArray = nullptr;
             g_serializeToArray = nullptr;
             g_steamClientBase = 0;
-        } else if ((uintptr_t)currentSC != g_steamClientBase) {
-            LOG("Shutdown: steamclient64.dll base changed (%p -> %p), skipping vtable restore",
-                (void*)g_steamClientBase, (void*)currentSC);
+        } else if (currentBase != g_steamClientBase) {
+            LOG("Shutdown: steamclient base changed (%p -> %p), skipping vtable restore",
+                (void*)g_steamClientBase, (void*)currentBase);
             g_vtableHookInstalled.store(false, std::memory_order_release);
             // Module rebased: every cached absolute pointer is wrong for the new base.
             g_serviceTransportVtableEa = 0;
@@ -4477,7 +4547,7 @@ static void ShutdownImpl() {
             g_originalSlot8 = nullptr;
             g_parseFromArray = nullptr;
             g_serializeToArray = nullptr;
-            g_steamClientBase = (uintptr_t)currentSC;
+            g_steamClientBase = currentBase;
         } else {
             // Restore against the same vtable EA the install patched. If RTTI never resolved
             // (shouldn't be possible while g_vtableHookInstalled is true), fall back to

--- a/src/platform/win/dllmain.cpp
+++ b/src/platform/win/dllmain.cpp
@@ -74,6 +74,82 @@ int CloudOnSendPkt(void* thisptr, const uint8_t* data, uint32_t size, void* recv
     return CloudIntercept::OnSendPkt(thisptr, data, size) ? 1 : 0;
 }
 
+// Local declarations for LdrRegisterDllNotification (NTDLL); not in winternl.h.
+namespace {
+struct CR_UNICODE_STRING {
+    USHORT Length;
+    USHORT MaximumLength;
+    PWCH   Buffer;
+};
+struct CR_LDR_DLL_LOADED_NOTIFICATION_DATA {
+    ULONG Flags;
+    const CR_UNICODE_STRING* FullDllName;
+    const CR_UNICODE_STRING* BaseDllName;
+    PVOID DllBase;
+    ULONG SizeOfImage;
+};
+union CR_LDR_DLL_NOTIFICATION_DATA {
+    CR_LDR_DLL_LOADED_NOTIFICATION_DATA Loaded;
+    CR_LDR_DLL_LOADED_NOTIFICATION_DATA Unloaded;
+};
+constexpr ULONG CR_LDR_DLL_NOTIFICATION_REASON_LOADED = 1;
+using CR_PLDR_DLL_NOTIFICATION_FUNCTION = VOID (CALLBACK*)(
+    ULONG, const CR_LDR_DLL_NOTIFICATION_DATA*, PVOID);
+using CR_PfnLdrRegisterDllNotification = LONG (NTAPI*)(
+    ULONG, CR_PLDR_DLL_NOTIFICATION_FUNCTION, PVOID, PVOID*);
+}
+
+static HANDLE g_diversionLoadedEvent = nullptr;
+static PVOID  g_dllNotifyCookie = nullptr;
+
+// Runs under the loader lock; must not allocate, take locks, or block.
+static VOID CALLBACK OnDllLoaded(
+    ULONG reason,
+    const CR_LDR_DLL_NOTIFICATION_DATA* data,
+    PVOID /*context*/)
+{
+    if (reason != CR_LDR_DLL_NOTIFICATION_REASON_LOADED) return;
+    if (!data || !data->Loaded.BaseDllName || !data->Loaded.BaseDllName->Buffer) return;
+    if (_wcsicmp(data->Loaded.BaseDllName->Buffer, L"diversion.dll") == 0) {
+        SetEvent(g_diversionLoadedEvent);
+    }
+}
+
+// Waits for diversion.dll to be mapped, then drives CR init by invoking
+// CloudOnSendPkt with null args. CR's vtable hooks resolve their module
+// base from diversion.dll under OpenSteamTool.
+static DWORD WINAPI SelfInitThread(LPVOID /*param*/) {
+    if (GetModuleHandleA("diversion.dll") != nullptr) {
+        CloudOnSendPkt(nullptr, nullptr, 0, nullptr);
+        return 0;
+    }
+
+    HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+    if (!ntdll) return 0;
+    auto pReg = reinterpret_cast<CR_PfnLdrRegisterDllNotification>(
+        GetProcAddress(ntdll, "LdrRegisterDllNotification"));
+    if (!pReg) return 0;
+
+    g_diversionLoadedEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (!g_diversionLoadedEvent) return 0;
+
+    if (pReg(0, OnDllLoaded, nullptr, &g_dllNotifyCookie) != 0) {
+        CloseHandle(g_diversionLoadedEvent);
+        g_diversionLoadedEvent = nullptr;
+        return 0;
+    }
+
+    // Closes the window where diversion.dll loaded between the initial check
+    // and the subscription taking effect.
+    if (GetModuleHandleA("diversion.dll") != nullptr) {
+        SetEvent(g_diversionLoadedEvent);
+    }
+
+    WaitForSingleObject(g_diversionLoadedEvent, INFINITE);
+    CloudOnSendPkt(nullptr, nullptr, 0, nullptr);
+    return 0;
+}
+
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID reserved) {
     switch (reason) {
     case DLL_PROCESS_ATTACH:
@@ -87,6 +163,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID reserved) {
                 GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
                 reinterpret_cast<LPCSTR>(&DllMain),
                 &pinned);
+        }
+
+        {
+            HANDLE h = CreateThread(nullptr, 0, SelfInitThread, nullptr, 0, nullptr);
+            if (h) CloseHandle(h);
         }
         break;
 

--- a/src/platform/win/ost_chainloader.cpp
+++ b/src/platform/win/ost_chainloader.cpp
@@ -1,0 +1,54 @@
+// Loader for CloudRedirect under OpenSteamTool.
+//
+// Installed as `cr_loader.dll` in the Steam folder. OST's xinput1_4.dll and
+// dwmapi.dll have their `"OpenSteamTool.dll"` string in .rdata replaced with
+// `"cr_loader.dll"`, so OST's existing `LoadLibraryA(...)` call resolves to
+// this stub instead. The real `OpenSteamTool.dll` stays at its natural
+// filename, untouched; the stub loads it (which runs OST's real DllMain)
+// and then loads `cloud_redirect.dll`.
+//
+// OST has zero exports (verified via IDA: only DllEntryPoint and a TLS
+// callback), so no export forwarding is required. The stub just needs to
+// return a non-NULL HMODULE so OST's `LoadLibraryA(...) != NULL` check passes.
+
+#include <windows.h>
+#include <string.h>
+
+static const char kRealOstName[] = "OpenSteamTool.dll";
+static const char kCloudRedirectName[] = "cloud_redirect.dll";
+
+static BOOL LoadSiblings(HMODULE selfModule) {
+    char selfPath[MAX_PATH];
+    DWORD n = GetModuleFileNameA(selfModule, selfPath, MAX_PATH);
+    if (n == 0 || n >= MAX_PATH) return FALSE;
+
+    // Truncate to "<dir>\" (keep trailing backslash for concatenation).
+    char* lastSlash = strrchr(selfPath, '\\');
+    if (!lastSlash) return FALSE;
+    *(lastSlash + 1) = '\0';
+    size_t dirLen = (size_t)(lastSlash + 1 - selfPath);
+    if (dirLen + sizeof(kRealOstName) > MAX_PATH ||
+        dirLen + sizeof(kCloudRedirectName) > MAX_PATH) return FALSE;
+
+    char ostPath[MAX_PATH];
+    memcpy(ostPath, selfPath, dirLen);
+    memcpy(ostPath + dirLen, kRealOstName, sizeof(kRealOstName));
+    HMODULE hOst = LoadLibraryA(ostPath);
+    if (!hOst) return FALSE;
+
+    char crPath[MAX_PATH];
+    memcpy(crPath, selfPath, dirLen);
+    memcpy(crPath + dirLen, kCloudRedirectName, sizeof(kCloudRedirectName));
+    LoadLibraryA(crPath); // optional; CR may not be deployed
+
+    return TRUE;
+}
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID) {
+    switch (reason) {
+    case DLL_PROCESS_ATTACH:
+        DisableThreadLibraryCalls(hModule);
+        return LoadSiblings(hModule);
+    }
+    return TRUE;
+}

--- a/ui/CloudRedirect.csproj
+++ b/ui/CloudRedirect.csproj
@@ -39,6 +39,8 @@
       <NativeDllDest>$(MSBuildProjectDirectory)\Resources\cloud_redirect.dll</NativeDllDest>
       <NativeCliSource>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\build\Release\cloud_redirect_cli.exe'))</NativeCliSource>
       <NativeCliDest>$(MSBuildProjectDirectory)\Resources\cloud_redirect_cli.exe</NativeCliDest>
+      <OstChainSource>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\build\Release\cr_loader.dll'))</OstChainSource>
+      <OstChainDest>$(MSBuildProjectDirectory)\Resources\cr_loader.dll</OstChainDest>
     </PropertyGroup>
     <MakeDir Directories="$(MSBuildProjectDirectory)\Resources" Condition="!Exists('$(MSBuildProjectDirectory)\Resources')" />
     <Copy SourceFiles="$(NativeDllSource)" DestinationFiles="$(NativeDllDest)"
@@ -47,16 +49,24 @@
     <Copy SourceFiles="$(NativeCliSource)" DestinationFiles="$(NativeCliDest)"
           Condition="Exists('$(NativeCliSource)')"
           SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OstChainSource)" DestinationFiles="$(OstChainDest)"
+          Condition="Exists('$(OstChainSource)')"
+          SkipUnchangedFiles="true" />
     <ItemGroup Condition="Exists('$(NativeDllDest)')">
       <EmbeddedResource Include="$(NativeDllDest)" LogicalName="cloud_redirect.dll" />
     </ItemGroup>
     <ItemGroup Condition="Exists('$(NativeCliDest)')">
       <EmbeddedResource Include="$(NativeCliDest)" LogicalName="cloud_redirect_cli.exe" />
     </ItemGroup>
+    <ItemGroup Condition="Exists('$(OstChainDest)')">
+      <EmbeddedResource Include="$(OstChainDest)" LogicalName="cr_loader.dll" />
+    </ItemGroup>
     <Warning Text="cloud_redirect.dll not found at $(NativeDllSource) — embedded resource will be stale or missing"
              Condition="!Exists('$(NativeDllSource)')" />
     <Warning Text="cloud_redirect_cli.exe not found at $(NativeCliSource) — embedded CLI will be stale or missing"
              Condition="!Exists('$(NativeCliSource)')" />
+    <Warning Text="cr_loader.dll not found at $(OstChainSource) — OST install path will not work"
+             Condition="!Exists('$(OstChainSource)')" />
   </Target>
 
   <ItemGroup>

--- a/ui/Pages/ChoiceModePage.xaml
+++ b/ui/Pages/ChoiceModePage.xaml
@@ -16,6 +16,45 @@
                        TextWrapping="Wrap"
                        Margin="0,0,0,24" />
 
+            <!-- OST host banner (shown when OpenSteamTool detected) -->
+            <Border x:Name="OstHostBanner"
+                    Visibility="Collapsed"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    BorderBrush="{DynamicResource SystemAccentColorPrimaryBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="16"
+                    Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="{res:Loc Choice_OstHost_Title}"
+                               FontSize="14" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+                    <TextBlock Text="{res:Loc Choice_OstHost_Description}"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0" />
+                </StackPanel>
+            </Border>
+
+            <Border x:Name="NoHostBanner"
+                    Visibility="Collapsed"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    BorderBrush="#CC2222"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="16"
+                    Margin="0,0,0,24">
+                <StackPanel>
+                    <TextBlock Text="{res:Loc Choice_NoHost_Title}"
+                               FontSize="14" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+                    <TextBlock Text="{res:Loc Choice_NoHost_Description}"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0" />
+                </StackPanel>
+            </Border>
+
             <!-- Current mode status (shown when mode already set) -->
             <Border x:Name="CurrentModeBanner"
                     Visibility="Collapsed"

--- a/ui/Pages/ChoiceModePage.xaml.cs
+++ b/ui/Pages/ChoiceModePage.xaml.cs
@@ -14,6 +14,7 @@ namespace CloudRedirect.Pages;
 public partial class ChoiceModePage : Page
 {
     private string? _currentMode;
+    private HostKind _host;
 
     public ChoiceModePage()
     {
@@ -31,13 +32,28 @@ public partial class ChoiceModePage : Page
     // state. Resolve the mode in Task.Run, then apply visibility.
     private async Task RefreshStateAsync()
     {
-        var mode = await Task.Run(() => SteamDetector.ReadModeSetting());
+        var (mode, host) = await Task.Run(() =>
+            (SteamDetector.ReadModeSetting(), SteamDetector.DetectHost()));
+        _host = host;
         ApplyMode(mode);
     }
 
     private void ApplyMode(string? mode)
     {
         _currentMode = mode;
+
+        OstHostBanner.Visibility = _host == HostKind.OpenSteamTool
+            ? Visibility.Visible : Visibility.Collapsed;
+        NoHostBanner.Visibility = _host == HostKind.None
+            ? Visibility.Visible : Visibility.Collapsed;
+
+        if (_host == HostKind.None)
+        {
+            CurrentModeBanner.Visibility = Visibility.Collapsed;
+            STFixerCard.Visibility = Visibility.Collapsed;
+            CloudRedirectCard.Visibility = Visibility.Collapsed;
+            return;
+        }
 
         if (_currentMode != null)
         {
@@ -55,19 +71,22 @@ public partial class ChoiceModePage : Page
                 CurrentModeText.Text = S.Get("Choice_CurrentMode_STFixer");
                 CurrentModeDescription.Text = S.Get("Choice_CurrentMode_STFixer_Desc");
                 STFixerCard.Visibility = Visibility.Collapsed;
-                CloudRedirectCard.Visibility = Visibility.Visible;
+                CloudRedirectCard.Visibility = _host == HostKind.OpenSteamTool
+                    ? Visibility.Collapsed : Visibility.Visible;
             }
         }
         else
         {
             CurrentModeBanner.Visibility = Visibility.Collapsed;
-            STFixerCard.Visibility = Visibility.Visible;
+            STFixerCard.Visibility = _host == HostKind.OpenSteamTool
+                ? Visibility.Collapsed : Visibility.Visible;
             CloudRedirectCard.Visibility = Visibility.Visible;
         }
     }
 
     private async void STFixerCard_Click(object sender, MouseButtonEventArgs e)
     {
+        if (_host == HostKind.OpenSteamTool) return;
         if (_currentMode == "cloud_redirect") return;
 
         if (!await TryPersistModeAsync("stfixer", cloudRedirectEnabled: false))

--- a/ui/Pages/CleanupPage.xaml
+++ b/ui/Pages/CleanupPage.xaml
@@ -17,6 +17,25 @@
                        TextWrapping="Wrap"
                        Margin="0,0,0,24" />
 
+            <Border x:Name="OstContextBanner"
+                    Visibility="Collapsed"
+                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                    BorderBrush="{DynamicResource SystemAccentColorPrimaryBrush}"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="16"
+                    Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="{res:Loc Cleanup_OstBanner_Title}"
+                               FontSize="14" FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+                    <TextBlock Text="{res:Loc Cleanup_OstBanner_Description}"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0" />
+                </StackPanel>
+            </Border>
+
             <StackPanel x:Name="ScanCleanPanel">
 
                 <WrapPanel Margin="0,0,0,16">

--- a/ui/Pages/CleanupPage.xaml.cs
+++ b/ui/Pages/CleanupPage.xaml.cs
@@ -64,6 +64,10 @@ public partial class CleanupPage : Page
         if (steamPath == null) return;
         _steamPath = steamPath;
 
+        var host = await Task.Run(() => SteamDetector.DetectHost(steamPath));
+        OstContextBanner.Visibility = host == HostKind.OpenSteamTool
+            ? Visibility.Visible : Visibility.Collapsed;
+
         var saved = LoadCleanupState(steamPath);
         if (saved == null) return;
 

--- a/ui/Pages/SettingsPage.xaml.cs
+++ b/ui/Pages/SettingsPage.xaml.cs
@@ -13,7 +13,7 @@ namespace CloudRedirect.Pages;
 
 public partial class SettingsPage : Page
 {
-    private const string ReleasesUrl = "https://github.com/Selectively11/CloudRedirect/releases";
+    private const string ReleasesUrl = "https://github.com/JanitorialMess/CloudRedirect/releases";
 
     private string? _latestDownloadUrl;
     private bool _languageLoading;

--- a/ui/Pages/SetupPage.xaml.cs
+++ b/ui/Pages/SetupPage.xaml.cs
@@ -573,6 +573,21 @@ public partial class SetupPage : Page
     {
         if (_isRunning || _steamPath == null) return;
 
+        var host = Services.SteamDetector.DetectHost(_steamPath);
+
+        if (host == Services.HostKind.Both)
+        {
+            await Services.Dialog.ShowWarningAsync(S.Get("Setup_TwoUnlockersTitle"),
+                S.Get("Setup_TwoUnlockersMessage"));
+            return;
+        }
+
+        if (host == Services.HostKind.OpenSteamTool)
+        {
+            await RunAllOst();
+            return;
+        }
+
         var confirm = await Services.Dialog.ConfirmAsync(S.Get("Setup_RunAllPatches"),
             S.Get("Setup_ConfirmRunAll"));
 
@@ -797,6 +812,81 @@ public partial class SetupPage : Page
                 await WriteDefaultLocalConfig();
             }
         }
+
+        SetBusy(false);
+    }
+
+    private async Task RunAllOst()
+    {
+        if (_steamPath == null) return;
+
+        var confirm = await Services.Dialog.ConfirmAsync(S.Get("Setup_RunAllPatches"),
+            S.Get("Setup_ConfirmRunAllOst"));
+        if (!confirm) return;
+
+        SetBusy(true);
+        ClearLog();
+
+        await EnsureSteamClosed();
+
+        bool allOk = true;
+
+        Log("═══ " + S.Get("Setup_OstDeployHeader") + " ═══");
+        try
+        {
+            var destPath = Path.Combine(_steamPath, "cloud_redirect.dll");
+            var deployError = await Task.Run(() => EmbeddedDll.DeployTo(destPath));
+
+            if (deployError != null)
+            {
+                Log($"FAILED: {deployError}");
+                DeployStatusText.Text = S.Get("Setup_DeployFailed");
+                allOk = false;
+            }
+            else
+            {
+                var info = new FileInfo(destPath);
+                DeployStatusText.Text = S.Format("Setup_DllInstalled",
+                    info.Length.ToString("N0"), info.LastWriteTime.ToString("g"));
+                Log($"Deployed to {destPath}");
+                Log("OK");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log($"FAILED: {ex.Message}");
+            DeployStatusText.Text = S.Get("Setup_DeployFailed");
+            allOk = false;
+        }
+
+        Log("");
+        Log("═══ " + S.Get("Setup_OstLoaderHeader") + " ═══");
+        try
+        {
+            PatchResult? patchResult = null;
+            await Task.Run(() =>
+            {
+                patchResult = OstLoaderPatcher.Apply(_steamPath, Log);
+            });
+
+            if (patchResult?.Succeeded == true)
+            {
+                Log("OK");
+            }
+            else
+            {
+                Log($"FAILED: {patchResult?.Error ?? "Unknown error"}");
+                allOk = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log($"FAILED: {ex.Message}");
+            allOk = false;
+        }
+
+        Log("");
+        Log(allOk ? S.Get("Setup_OstInstallComplete") : S.Get("Setup_OstInstallFailed"));
 
         SetBusy(false);
     }

--- a/ui/Resources/Strings.resx
+++ b/ui/Resources/Strings.resx
@@ -119,6 +119,18 @@
   <data name="Choice_FailedSaveMode" xml:space="preserve">
     <value>Couldn't save your selection: {0}</value>
   </data>
+  <data name="Choice_OstHost_Title" xml:space="preserve">
+    <value>OpenSteamTool detected</value>
+  </data>
+  <data name="Choice_OstHost_Description" xml:space="preserve">
+    <value>STFixer mode applies only to SteamTools. Use Cloud Redirect mode.</value>
+  </data>
+  <data name="Choice_NoHost_Title" xml:space="preserve">
+    <value>No supported unlocker detected</value>
+  </data>
+  <data name="Choice_NoHost_Description" xml:space="preserve">
+    <value>Install SteamTools or OpenSteamTool next to steam.exe.</value>
+  </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- SetupPage XAML                                                     -->
@@ -268,6 +280,12 @@
   </data>
   <data name="Setup_PatchState_Unknown" xml:space="preserve">
     <value>Unknown</value>
+  </data>
+  <data name="Setup_OstSkippedMessage" xml:space="preserve">
+    <value>OpenSteamTool detected -- SteamTools-only step skipped.</value>
+  </data>
+  <data name="Setup_BothUnlockersLog" xml:space="preserve">
+    <value>Both SteamTools and OpenSteamTool files found in the Steam folder -- remove one and try again.</value>
   </data>
   <data name="Setup_OfflinePatched" xml:space="preserve">
     <value>Patched (offline mode enabled)</value>
@@ -1049,6 +1067,12 @@ Skipped {0} file(s) (already exist at original location).</value>
   </data>
   <data name="Cleanup_Description" xml:space="preserve">
     <value>SteamTools redirected all lua apps' cloud saves through app 760, polluting every game's remote/ folder with every other game's files. Scan to see which apps are affected, then select files to remove.</value>
+  </data>
+  <data name="Cleanup_OstBanner_Title" xml:space="preserve">
+    <value>OpenSteamTool detected</value>
+  </data>
+  <data name="Cleanup_OstBanner_Description" xml:space="preserve">
+    <value>OpenSteamTool does not route cloud saves through app 760. This page is for cleaning up files left by a prior SteamTools install.</value>
   </data>
   <data name="Cleanup_ScanForContamination" xml:space="preserve">
     <value>Scan for Contamination</value>

--- a/ui/Resources/Strings.resx
+++ b/ui/Resources/Strings.resx
@@ -281,11 +281,40 @@
   <data name="Setup_PatchState_Unknown" xml:space="preserve">
     <value>Unknown</value>
   </data>
+  <data name="Setup_ConfirmRunAllOst" xml:space="preserve">
+    <value>This will deploy the DLL and patch OpenSteamTool to load it:
+
+  1. Deploy cloud_redirect.dll
+  2. Patch OpenSteamTool loader
+
+If Steam is running, it will be closed automatically.
+Backups will be created.
+
+Continue?</value>
+  </data>
+  <data name="Setup_TwoUnlockersTitle" xml:space="preserve">
+    <value>Two Unlockers Detected</value>
+  </data>
+  <data name="Setup_TwoUnlockersMessage" xml:space="preserve">
+    <value>SteamTools and OpenSteamTool files were both found in the Steam folder. Remove one and try again.</value>
+  </data>
   <data name="Setup_OstSkippedMessage" xml:space="preserve">
     <value>OpenSteamTool detected -- SteamTools-only step skipped.</value>
   </data>
   <data name="Setup_BothUnlockersLog" xml:space="preserve">
     <value>Both SteamTools and OpenSteamTool files found in the Steam folder -- remove one and try again.</value>
+  </data>
+  <data name="Setup_OstDeployHeader" xml:space="preserve">
+    <value>Step 1/2: Deploy cloud_redirect.dll</value>
+  </data>
+  <data name="Setup_OstLoaderHeader" xml:space="preserve">
+    <value>Step 2/2: Patch OpenSteamTool loader</value>
+  </data>
+  <data name="Setup_OstInstallComplete" xml:space="preserve">
+    <value>CloudRedirect installed. Launch Steam to verify.</value>
+  </data>
+  <data name="Setup_OstInstallFailed" xml:space="preserve">
+    <value>Some steps failed -- review the log above.</value>
   </data>
   <data name="Setup_OfflinePatched" xml:space="preserve">
     <value>Patched (offline mode enabled)</value>

--- a/ui/Services/AppUpdater.cs
+++ b/ui/Services/AppUpdater.cs
@@ -15,7 +15,7 @@ namespace CloudRedirect.Services;
 /// </summary>
 internal static class AppUpdater
 {
-    private const string RepoOwner = "Selectively11";
+    private const string RepoOwner = "JanitorialMess";
     private const string RepoName = "CloudRedirect";
     // Uses /releases (not /releases/latest) so prerelease/draft flags and tag
     // suffixes can be filtered client-side.

--- a/ui/Services/Patching/OstLoaderPatcher.cs
+++ b/ui/Services/Patching/OstLoaderPatcher.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace CloudRedirect.Services.Patching
+{
+    /// <summary>
+    /// Installs CloudRedirect autoload under OpenSteamTool. Rewrites the
+    /// "OpenSteamTool.dll" string in OST's hijack DLLs (xinput1_4.dll, dwmapi.dll)
+    /// to "cr_loader.dll"; the same call site then loads our chain-loader stub,
+    /// which loads the real OpenSteamTool.dll (unchanged at its natural filename)
+    /// and cloud_redirect.dll.
+    /// </summary>
+    internal static class OstLoaderPatcher
+    {
+        const string LoaderName = "cr_loader.dll";
+        const string LoaderResource = "cr_loader.dll";
+
+        static readonly string[] HijackCandidates = { "xinput1_4.dll", "dwmapi.dll" };
+
+        // "OpenSteamTool.dll" -- 17 bytes (no null). Used to locate the slot.
+        static readonly byte[] OstStringBytes =
+            System.Text.Encoding.ASCII.GetBytes("OpenSteamTool.dll");
+
+        // "cr_loader.dll\0" -- 14 bytes. Written into the 18-byte slot
+        // occupied by "OpenSteamTool.dll\0"; trailing bytes are zeroed.
+        static readonly byte[] LoaderStringBytes =
+            System.Text.Encoding.ASCII.GetBytes("cr_loader.dll\0");
+
+        const int OstSlotBytes = 18; // "OpenSteamTool.dll" + null
+
+        static List<string> FindHijackDlls(string steamPath)
+        {
+            var result = new List<string>();
+            foreach (var name in HijackCandidates)
+            {
+                var path = Path.Combine(steamPath, name);
+                if (!File.Exists(path)) continue;
+                byte[] data;
+                try { data = File.ReadAllBytes(path); }
+                catch (IOException) { continue; }
+                bool hasOstString = Signatures.ScanForBytes(data, 0, data.Length, OstStringBytes) >= 0;
+                bool hasLoaderMarker = Signatures.ScanForBytes(data, 0, data.Length, LoaderStringBytes) >= 0;
+                if (hasOstString || hasLoaderMarker) result.Add(path);
+            }
+            return result;
+        }
+
+        public static PatchResult Apply(string steamPath, Action<string> log = null)
+        {
+            var result = new PatchResult();
+
+            var loaderBytes = LoadLoaderResource();
+            if (loaderBytes == null || loaderBytes.Length == 0)
+                return result.Fail("cr_loader.dll resource missing from launcher build.");
+
+            var hijacks = FindHijackDlls(steamPath);
+            if (hijacks.Count == 0)
+                return result.Fail("OpenSteamTool hijack DLLs not found in Steam folder.");
+
+            int patched = 0, already = 0;
+            foreach (var path in hijacks)
+            {
+                var name = Path.GetFileName(path);
+                try
+                {
+                    var bytes = File.ReadAllBytes(path);
+
+                    if (Signatures.ScanForBytes(bytes, 0, bytes.Length, LoaderStringBytes) >= 0)
+                    {
+                        log?.Invoke($"  {name}: string already patched");
+                        already++;
+                        continue;
+                    }
+
+                    int strOffset = Signatures.ScanForBytes(bytes, 0, bytes.Length, OstStringBytes);
+                    if (strOffset < 0)
+                    {
+                        log?.Invoke($"  {name}: OpenSteamTool.dll string not found, skipping");
+                        continue;
+                    }
+                    // Slot must include the trailing null.
+                    if (strOffset + OstSlotBytes > bytes.Length ||
+                        bytes[strOffset + OstStringBytes.Length] != 0)
+                    {
+                        log?.Invoke($"  {name}: string not null-terminated where expected, skipping");
+                        continue;
+                    }
+
+                    // Overwrite the full 18-byte slot so trailing bytes of the
+                    // original "OpenSteamTool.dll" don't linger past the new null.
+                    var slot = new byte[OstSlotBytes];
+                    Buffer.BlockCopy(LoaderStringBytes, 0, slot, 0, LoaderStringBytes.Length);
+                    Buffer.BlockCopy(slot, 0, bytes, strOffset, OstSlotBytes);
+
+                    FileUtils.AtomicWriteAllBytes(path, bytes);
+                    log?.Invoke($"  {name}: string patched -> cr_loader.dll");
+                    patched++;
+                }
+                catch (Exception ex)
+                {
+                    return result.Fail($"{name}: {ex.Message}");
+                }
+            }
+
+            if (patched == 0 && already == 0)
+                return result.Fail("No OST hijack DLL had a patchable string.");
+
+            try
+            {
+                var loaderDest = Path.Combine(steamPath, LoaderName);
+                FileUtils.AtomicWriteAllBytes(loaderDest, loaderBytes);
+                log?.Invoke($"  {LoaderName}: deployed ({loaderBytes.Length} bytes)");
+            }
+            catch (Exception ex)
+            {
+                return result.Fail($"{LoaderName} deploy failed: {ex.Message}");
+            }
+
+            result.Succeeded = true;
+            result.DllPatched = patched > 0;
+            return result;
+        }
+
+        static byte[] LoadLoaderResource()
+        {
+            using var stream = typeof(OstLoaderPatcher).Assembly
+                .GetManifestResourceStream(LoaderResource);
+            if (stream == null) return null;
+            using var ms = new MemoryStream(checked((int)stream.Length));
+            stream.CopyTo(ms);
+            return ms.ToArray();
+        }
+    }
+}

--- a/ui/Services/Patching/Patcher.cs
+++ b/ui/Services/Patching/Patcher.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using CloudRedirect.Resources;
 using CloudRedirect.Services;
 using Microsoft.Win32;
 
@@ -228,6 +229,18 @@ namespace CloudRedirect.Services.Patching
         {
             _verbose = true;
             var result = new PatchResult();
+
+            // xinput1_4 / dwmapi are OST's hijack DLLs; skip when OST is installed.
+            var host = SteamDetector.DetectHost(_steamPath);
+            if (host == HostKind.OpenSteamTool || host == HostKind.Both)
+            {
+                var reason = host == HostKind.Both
+                    ? S.Get("Setup_BothUnlockersLog")
+                    : S.Get("Setup_OstSkippedMessage");
+                Log(reason);
+                result.Error = reason;
+                return result;
+            }
 
             try
             {

--- a/ui/Services/SteamDetector.cs
+++ b/ui/Services/SteamDetector.cs
@@ -2,9 +2,18 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using CloudRedirect.Resources;
+using CloudRedirect.Services.Patching;
 using Microsoft.Win32;
 
 namespace CloudRedirect.Services;
+
+public enum HostKind
+{
+    None,           // no supported unlocker found next to steam.exe
+    SteamTools,     // ST AES key found in xinput1_4 / dwmapi
+    OpenSteamTool,  // OST marker found in xinput1_4 / dwmapi + sidecar OpenSteamTool.dll present
+    Both,           // both fingerprints present
+}
 
 /// <summary>
 /// Detects the Steam installation path via the Windows registry or well-known paths.
@@ -100,9 +109,57 @@ public static class SteamDetector
         }
         catch
         {
-            // Version parse can fail if manifest is malformed — not critical
+            // Version parse can fail if manifest is malformed -- not critical
         }
         return null;
+    }
+
+    // OST's hijack DLL has "OpenSteamTool.dll" in .rdata for its LoadLibraryA call.
+    // CloudRedirect's autoload install rewrites it to "cr_loader.dll".
+    private static readonly byte[] _ostMarker = System.Text.Encoding.ASCII.GetBytes("OpenSteamTool.dll");
+    private static readonly byte[] _crLoaderMarker = System.Text.Encoding.ASCII.GetBytes("cr_loader.dll");
+
+    /// <summary>
+    /// Returns which unlocker is installed next to steam.exe. Not cached --
+    /// re-reads xinput1_4.dll / dwmapi.dll on each call so install changes
+    /// between calls are picked up.
+    /// </summary>
+    public static HostKind DetectHost(string? steamPath = null)
+    {
+        steamPath ??= FindSteamPath();
+        if (steamPath == null || !Directory.Exists(steamPath))
+            return HostKind.None;
+
+        bool hasOstSidecar = File.Exists(Path.Combine(steamPath, "OpenSteamTool.dll"));
+
+        bool foundSt = false;
+        bool foundOst = false;
+
+        foreach (var name in new[] { "xinput1_4.dll", "dwmapi.dll" })
+        {
+            var path = Path.Combine(steamPath, name);
+            if (!File.Exists(path)) continue;
+
+            byte[] buf;
+            try { buf = File.ReadAllBytes(path); }
+            catch { continue; }
+
+            if (Signatures.ScanForBytes(buf, 0, buf.Length, SteamToolsCrypto.AesKey) >= 0)
+                foundSt = true;
+
+            if (Signatures.ScanForBytes(buf, 0, buf.Length, _ostMarker) >= 0 ||
+                Signatures.ScanForBytes(buf, 0, buf.Length, _crLoaderMarker) >= 0)
+                foundOst = true;
+        }
+
+        // OST requires BOTH a hijack-DLL marker (pristine or patched) AND the
+        // sidecar OpenSteamTool.dll -- either alone indicates a broken install.
+        bool isOst = foundOst && hasOstSidecar;
+
+        if (foundSt && isOst) return HostKind.Both;
+        if (foundSt) return HostKind.SteamTools;
+        if (isOst) return HostKind.OpenSteamTool;
+        return HostKind.None;
     }
 
     private static string? TryRegistry()


### PR DESCRIPTION
If you are going to build from every upstream commit, you may wind up compiling super WIP builds. It may be fine, it may result is some breakage. Probably not relevant to your use case right now  the breakage that could have happened since you put this together if someone was to build from source every commit was Linux specific - but there are going to be commits related to the Achievement Sync backend system and the Playtime Sync backend system in the near future (that is going to be developed in public).

The reason I don't support OpenSteamTool is that I have no way of communicating with the author to get some assurances that they will not do things with normal Steam Cloud behavior that would cause breakage for me. I don't mind if someone wants to support it in a fork, but I would hate for someone to experience bad problems because they built from source on every commit. 

If you insist, please change the path name for /CloudRedirect/ on the remote so as to avoid a user switching back to mainline CloudRedirect from experiencing potential data loss. 