### PR TITLE
Add Simplified Chinese (zh-CN) translation

### DIFF
--- a/ui/Pages/Cloud760Page.xaml
+++ b/ui/Pages/Cloud760Page.xaml
@@ -2,17 +2,18 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+      xmlns:res="clr-namespace:CloudRedirect.Resources"
       ScrollViewer.CanContentScroll="False">
 
     <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="24">
         <StackPanel MaxWidth="800">
 
-            <TextBlock Text="760 Clean Up"
+            <TextBlock Text="{res:Loc Cloud760_Title}"
                        FontSize="28" FontWeight="SemiBold"
                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                        Margin="0,0,0,8" />
 
-            <TextBlock Text="View and delete the saves SteamTools wrote to 760 (Steam Screenshots). This will stop SteamTools from redownloading those saves when run without CloudRedirect patches, preventing SteamTools from contaminating the userdata of each injected game."
+            <TextBlock Text="{res:Loc Cloud760_Description}"
                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                        TextWrapping="Wrap"
                        Margin="0,0,0,20" />
@@ -29,10 +30,10 @@
                                Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
                     <ui:TextBox x:Name="AppIdBox" Text="760" Width="96"
                                 VerticalAlignment="Center" Margin="0,0,12,0" />
-                    <ui:Button x:Name="ConnectButton" Content="Connect"
+                    <ui:Button x:Name="ConnectButton" Content="{res:Loc Cloud760_Connect}"
                                Icon="{ui:SymbolIcon Cloud24}" Appearance="Primary"
                                Click="ConnectButton_Click" Margin="0,0,8,0" />
-                    <ui:Button x:Name="RefreshButton" Content="Refresh"
+                    <ui:Button x:Name="RefreshButton" Content="{res:Loc Cloud760_Refresh}"
                                Icon="{ui:SymbolIcon ArrowSync24}" Appearance="Secondary"
                                IsEnabled="False" Click="RefreshButton_Click" />
                 </StackPanel>
@@ -52,22 +53,22 @@
             <ui:CardControl x:Name="EmptyHintCard" Margin="0,0,0,4">
                 <ui:CardControl.Header>
                     <StackPanel>
-                        <TextBlock Text="No files yet"
+                        <TextBlock Text="{res:Loc Cloud760_NoFilesYet}"
                                    FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
                         <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                    TextWrapping="Wrap" Margin="0,2,0,0">
-                            <Run Text="Connect to load your AppID 760 cloud files. If nothing shows up, open the Steam console, run " />
+                            <Run Text="{res:Loc Cloud760_NoFilesYet_Description}" />
                             <Run Text="cloud_sync_up 760" FontFamily="Consolas" />
-                            <Run Text=", then Refresh." />
+                            <Run Text="{res:Loc Cloud760_ThenRefresh}" />
                         </TextBlock>
                     </StackPanel>
                 </ui:CardControl.Header>
                 <StackPanel Orientation="Horizontal">
-                    <ui:Button x:Name="OpenConsoleButton" Content="Open Console"
+                    <ui:Button x:Name="OpenConsoleButton" Content="{res:Loc Cloud760_OpenConsole}"
                                Icon="{ui:SymbolIcon Window24}" Appearance="Secondary"
                                Click="OpenConsoleButton_Click" Margin="0,0,8,0" />
-                    <ui:Button x:Name="CopyCmdButton" Content="Copy Command"
+                    <ui:Button x:Name="CopyCmdButton" Content="{res:Loc Cloud760_CopyCommand}"
                                Icon="{ui:SymbolIcon Copy24}" Appearance="Secondary"
                                Click="CopyCmdButton_Click" />
                 </StackPanel>
@@ -85,9 +86,9 @@
                                VerticalAlignment="Center"
                                Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
                     <StackPanel Grid.Column="1" Orientation="Horizontal">
-                        <ui:Button Content="Select All" Appearance="Transparent"
+                        <ui:Button Content="{res:Loc Cloud760_SelectAll}" Appearance="Transparent"
                                    Click="SelectAll_Click" Margin="0,0,4,0" />
-                        <ui:Button Content="Clear" Appearance="Transparent"
+                        <ui:Button Content="{res:Loc Cloud760_Clear}" Appearance="Transparent"
                                    Click="ClearSelection_Click" />
                     </StackPanel>
                 </Grid>
@@ -148,19 +149,19 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" VerticalAlignment="Center">
-                            <TextBlock Text="Delete cloud files"
+                            <TextBlock Text="{res:Loc Cloud760_DeleteCloudFiles}"
                                        FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
-                            <TextBlock Text="Removing files here is permanent and cannot be undone."
+                            <TextBlock Text="{res:Loc Cloud760_DeleteWarning}"
                                        FontSize="12"
                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                        Margin="0,2,0,0" />
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                            <ui:Button x:Name="DeleteSelectedButton" Content="Delete Selected"
+                            <ui:Button x:Name="DeleteSelectedButton" Content="{res:Loc Cloud760_DeleteSelected}"
                                        Icon="{ui:SymbolIcon Delete24}" Appearance="Secondary"
                                        IsEnabled="False" Click="DeleteSelectedButton_Click" Margin="0,0,8,0" />
-                            <ui:Button x:Name="DeleteAllButton" Content="Delete All"
+                            <ui:Button x:Name="DeleteAllButton" Content="{res:Loc Cloud760_DeleteAll}"
                                        Icon="{ui:SymbolIcon Delete24}" Appearance="Danger"
                                        IsEnabled="False" Click="DeleteAllButton_Click" />
                         </StackPanel>

--- a/ui/Pages/Cloud760Page.xaml.cs
+++ b/ui/Pages/Cloud760Page.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using CloudRedirect.Resources;
 using CloudRedirect.Services;
 
 namespace CloudRedirect.Pages;
@@ -83,7 +84,9 @@ public partial class Cloud760Page : Page
     {
         int total = _files.Count;
         int sel = _files.Count(f => f.IsChecked);
-        SelectionText.Text = sel > 0 ? $"{sel} of {total} selected" : $"{total} file{(total == 1 ? "" : "s")}";
+        SelectionText.Text = sel > 0
+            ? S.Format("Cloud760_FilesSelected", sel, total)
+            : S.Format("Cloud760_FilesCount", total);
         bool connected = _cloud != null && !_busy;
         DeleteSelectedButton.IsEnabled = connected && sel > 0;
         DeleteAllButton.IsEnabled = connected && total > 0;
@@ -117,7 +120,7 @@ public partial class Cloud760Page : Page
     private void OpenConsoleButton_Click(object sender, RoutedEventArgs e)
     {
         SteamConsole.OpenConsole();
-        StatusText.Text = $"Steam console opened. Run 'cloud_sync_up {ParseAppId()}' there, then Connect.";
+        StatusText.Text = S.Format("Cloud760_ConsoleOpened", ParseAppId());
     }
 
     private void CopyCmdButton_Click(object sender, RoutedEventArgs e)
@@ -125,7 +128,7 @@ public partial class Cloud760Page : Page
         try
         {
             Clipboard.SetText($"cloud_sync_up {ParseAppId()}");
-            StatusText.Text = $"Copied 'cloud_sync_up {ParseAppId()}' to clipboard. Paste it into the Steam console.";
+            StatusText.Text = S.Format("Cloud760_CommandCopied", ParseAppId());
         }
         catch { /* clipboard can transiently fail; ignore */ }
     }
@@ -135,7 +138,7 @@ public partial class Cloud760Page : Page
         if (_busy) return;
         uint appId = ParseAppId();
         SetBusy(true);
-        StatusText.Text = $"Connecting to Steam Cloud as AppID {appId}...";
+        StatusText.Text = S.Format("Cloud760_Connecting", appId);
         _files.Clear();
         UpdateListVisibility();
 
@@ -158,17 +161,17 @@ public partial class Cloud760Page : Page
             _connectedAppId = appId;
 
             LoadRows(result.files);
-            QuotaText.Text = $"{FormatBytes(result.used)} / {FormatBytes(result.total)} used";
+            QuotaText.Text = S.Format("Cloud760_QuotaUsed", FormatBytes(result.used), FormatBytes(result.total));
             StatusText.Text = _files.Count > 0
-                ? $"Loaded {_files.Count} file(s) for AppID {appId}."
-                : $"Connected to AppID {appId}, but no cloud files were found.";
+                ? S.Format("Cloud760_LoadedFiles", _files.Count, appId)
+                : S.Format("Cloud760_ConnectedNoFiles", appId);
         }
         catch (Exception ex)
         {
             _cloud?.Dispose();
             _cloud = null;
             QuotaText.Text = "";
-            StatusText.Text = "Error: " + ex.Message;
+            StatusText.Text = S.Format("Cloud760_Error", ex.Message);
         }
         finally
         {
@@ -180,7 +183,7 @@ public partial class Cloud760Page : Page
     {
         if (_busy || _cloud == null) return;
         SetBusy(true);
-        StatusText.Text = "Refreshing...";
+        StatusText.Text = S.Get("Cloud760_Refreshing");
         try
         {
             var cloud = _cloud;
@@ -193,12 +196,12 @@ public partial class Cloud760Page : Page
             });
 
             LoadRows(result.files);
-            QuotaText.Text = $"{FormatBytes(result.used)} / {FormatBytes(result.total)} used";
-            StatusText.Text = $"Loaded {_files.Count} file(s) for AppID {appId}.";
+            QuotaText.Text = S.Format("Cloud760_QuotaUsed", FormatBytes(result.used), FormatBytes(result.total));
+            StatusText.Text = S.Format("Cloud760_LoadedFiles", _files.Count, appId);
         }
         catch (Exception ex)
         {
-            StatusText.Text = "Error: " + ex.Message;
+            StatusText.Text = S.Format("Cloud760_Error", ex.Message);
         }
         finally
         {
@@ -237,7 +240,7 @@ public partial class Cloud760Page : Page
         }
 
         SetBusy(true);
-        StatusText.Text = $"Deleting {names.Count} file(s)...";
+        StatusText.Text = S.Format("Cloud760_DeletingFiles", names.Count);
 
         try
         {
@@ -252,11 +255,13 @@ public partial class Cloud760Page : Page
                 return (ok, bad);
             });
 
-            StatusText.Text = $"Deleted {deleted} file(s)" + (failed > 0 ? $", {failed} failed." : ".");
+            StatusText.Text = failed > 0
+                ? S.Format("Cloud760_DeletedFilesFailed", deleted, failed)
+                : S.Format("Cloud760_DeletedFiles", deleted);
         }
         catch (Exception ex)
         {
-            StatusText.Text = "Error: " + ex.Message;
+            StatusText.Text = S.Format("Cloud760_Error", ex.Message);
         }
         finally
         {

--- a/ui/Pages/NewsPage.xaml
+++ b/ui/Pages/NewsPage.xaml
@@ -32,7 +32,7 @@
                 </DockPanel>
             </Border>
 
-            <TextBlock Text="What's new?"
+            <TextBlock Text="{res:Loc News_WhatsNew}"
                        FontSize="28" FontWeight="SemiBold"
                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                        Margin="0,0,0,24" />
@@ -41,9 +41,9 @@
             <ui:CardControl Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel>
-                        <TextBlock Text="Achievement and Playtime Sync" FontWeight="SemiBold"
+                        <TextBlock Text="{res:Loc News_AchievementSync_Title}" FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
-                        <TextBlock Text="Achievements and Playtime can now be synced to the cloud! Cross-device play is supported. Works through the normal Steam systems. Enable in Settings if you are interested. Note that this feature is experimental!"
+                        <TextBlock Text="{res:Loc News_AchievementSync_Description}"
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
@@ -54,9 +54,9 @@
             <ui:CardControl Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel>
-                        <TextBlock Text="Achievement Schema Fetching for SteamTools" FontWeight="SemiBold"
+                        <TextBlock Text="{res:Loc News_SchemaFetching_Title}" FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
-                        <TextBlock Text="CR can now fetch achievement schemas, so games that previously did not display achievements will now display them!"
+                        <TextBlock Text="{res:Loc News_SchemaFetching_Description}"
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
@@ -67,9 +67,9 @@
             <ui:CardControl Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel>
-                        <TextBlock Text="Show Lua Game in Status" FontWeight="SemiBold"
+                        <TextBlock Text="{res:Loc News_ShowLuaGame_Title}" FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
-                        <TextBlock Text="Lua apps can now appear in your Steam status. They appear as a non-Steam game with the correct game name. This change is on by default, disable in Settings if you don't want it."
+                        <TextBlock Text="{res:Loc News_ShowLuaGame_Description}"
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
@@ -80,9 +80,9 @@
             <ui:CardControl Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel>
-                        <TextBlock Text="760 Clean Up" FontWeight="SemiBold"
+                        <TextBlock Text="{res:Loc News_760CleanUp_Title}" FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
-                        <TextBlock Text="There is a new (experimental) tool that can delete the saves that SteamTools uploaded to AppID 760. Read the release notes on Github for more information."
+                        <TextBlock Text="{res:Loc News_760CleanUp_Description}"
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
@@ -93,9 +93,9 @@
             <ui:CardControl Margin="0,0,0,12">
                 <ui:CardControl.Header>
                     <StackPanel>
-                        <TextBlock Text="...and more!" FontWeight="SemiBold"
+                        <TextBlock Text="{res:Loc News_AndMore_Title}" FontWeight="SemiBold"
                                    Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
-                        <TextBlock Text="Bug fixes, Google Drive performance improvements, preparation work for future updates, unannounced features sprinkled throughout the CR UI. Fun for all!"
+                        <TextBlock Text="{res:Loc News_AndMore_Description}"
                                    TextWrapping="Wrap"
                                    Foreground="{DynamicResource TextFillColorSecondaryBrush}" />
                     </StackPanel>

--- a/ui/Pages/SettingsPage.xaml
+++ b/ui/Pages/SettingsPage.xaml
@@ -55,10 +55,10 @@
                     <ui:CardControl Margin="0,0,0,8">
                         <ui:CardControl.Header>
                             <StackPanel>
-                                <TextBlock Text="Auto Update"
+                                <TextBlock Text="{res:Loc Settings_AutoUpdate}"
                                            FontWeight="SemiBold"
                                            Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
-                                <TextBlock Text="Automatically download latest version of the Cloud Redirect DLL on Steam startup"
+                                <TextBlock Text="{res:Loc Settings_AutoUpdate_Description}"
                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                            TextWrapping="Wrap" />
                             </StackPanel>

--- a/ui/Pages/SetupPage.xaml
+++ b/ui/Pages/SetupPage.xaml
@@ -77,11 +77,11 @@
 
             <!-- Manifest endpoint override (ST-only) -->
             <StackPanel x:Name="ManifestEndpointSection" Margin="0,0,0,16">
-                <TextBlock Text="Manifest Endpoint"
+                <TextBlock Text="{res:Loc Setup_ManifestEndpoint}"
                            FontSize="20" FontWeight="SemiBold"
                            Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                            Margin="0,0,0,8" />
-                <TextBlock Text="Override the manifest download URL and User-Agent used by SteamTools. Leave empty to use the default."
+                <TextBlock Text="{res:Loc Setup_ManifestEndpoint_Description}"
                            Foreground="{DynamicResource TextFillColorTertiaryBrush}"
                            TextWrapping="Wrap"
                            Margin="0,0,0,12" />

--- a/ui/Pages/StatsPage.xaml.cs
+++ b/ui/Pages/StatsPage.xaml.cs
@@ -67,7 +67,7 @@ public partial class StatsPage : Page
 
     private async Task LoadStatsAsync()
     {
-        ShowStatus("Loading data from cloud…");
+        ShowStatus(S.Get("Stats_LoadingFromCloud"));
         CloudUnavailableText.Visibility = Visibility.Collapsed;
         EmptyText.Visibility = Visibility.Collapsed;
 

--- a/ui/Resources/Strings.zh-CN.resx
+++ b/ui/Resources/Strings.zh-CN.resx
@@ -50,679 +50,673 @@
     <value>CloudRedirect</value>
   </data>
   <data name="Nav_Dashboard" xml:space="preserve">
-    <value>Dashboard</value>
+    <value>仪表板</value>
   </data>
   <data name="Nav_Setup" xml:space="preserve">
-    <value>Setup</value>
+    <value>设置</value>
   </data>
   <data name="Nav_CloudProvider" xml:space="preserve">
-    <value>Cloud Provider</value>
+    <value>云存储提供商</value>
   </data>
   <data name="Nav_Apps" xml:space="preserve">
-    <value>Apps</value>
+    <value>应用</value>
   </data>
   <data name="Nav_Cleanup" xml:space="preserve">
-    <value>Clean Up</value>
+    <value>清理</value>
   </data>
   <data name="Nav_ManifestPinning" xml:space="preserve">
-    <value>Manifest Pinning</value>
+    <value>清单固定</value>
   </data>
   <data name="Nav_Stats" xml:space="preserve">
-    <value>Achievements &amp; Playtime</value>
+    <value>成就与游戏时长</value>
   </data>
   <data name="Stats_Hint" xml:space="preserve">
-    <value>View current cloud achievement/playtime data for your injected apps.</value>
+    <value>查看已注入应用的云成就/游戏时长数据。</value>
   </data>
   <data name="Stats_Refresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>刷新</value>
   </data>
   <data name="Stats_NoData" xml:space="preserve">
-    <value>No synced stats found in the cloud yet. Launch a Lua-unlocked game with CloudRedirect active, let it sync, then refresh.</value>
+    <value>云端尚未找到同步的统计数据。启动一个已解锁 Lua 的游戏并使用 CloudRedirect，让它同步后再刷新。</value>
   </data>
   <data name="Stats_NoCloud" xml:space="preserve">
-    <value>No cloud provider is configured. Set up Google Drive, OneDrive, or a folder in Cloud Provider settings to view synced stats.</value>
+    <value>未配置云存储提供商。在云存储提供商设置中配置 Google Drive、OneDrive 或文件夹以查看同步的统计数据。</value>
   </data>
   <data name="Stats_AppFallbackName" xml:space="preserve">
-    <value>App {0}</value>
+    <value>应用 {0}</value>
   </data>
   <data name="Stats_AccountHeader" xml:space="preserve">
-    <value>Account {0}</value>
+    <value>账户 {0}</value>
   </data>
   <data name="Stats_PlaytimeForever" xml:space="preserve">
-    <value>PLAYTIME (TOTAL)</value>
+    <value>游戏时长（总计）</value>
   </data>
   <data name="Stats_Playtime2Weeks" xml:space="preserve">
-    <value>LAST 2 WEEKS</value>
+    <value>最近两周</value>
   </data>
   <data name="Stats_LastPlayed" xml:space="preserve">
-    <value>LAST PLAYED</value>
+    <value>最后游戏</value>
   </data>
   <data name="Stats_AchievementsHeader" xml:space="preserve">
-    <value>Achievements</value>
+    <value>成就</value>
   </data>
   <data name="Stats_StatsHeader" xml:space="preserve">
-    <value>Stats</value>
+    <value>统计</value>
   </data>
   <data name="Stats_Minutes" xml:space="preserve">
-    <value>{0} min</value>
+    <value>{0} 分钟</value>
   </data>
   <data name="Stats_Hours" xml:space="preserve">
-    <value>{0} h</value>
+    <value>{0} 小时</value>
   </data>
   <data name="Stats_NoPlaytime" xml:space="preserve">
-    <value>None</value>
+    <value>无</value>
   </data>
   <data name="Stats_Never" xml:space="preserve">
-    <value>Never</value>
+    <value>从未</value>
   </data>
   <data name="Stats_Locked" xml:space="preserve">
-    <value>Locked</value>
+    <value>未解锁</value>
   </data>
   <data name="Stats_StatId" xml:space="preserve">
-    <value>Stat {0}</value>
+    <value>统计 {0}</value>
   </data>
   <data name="Stats_AchievementBit" xml:space="preserve">
-    <value>Stat {0} · bit {1}</value>
+    <value>统计 {0} · 位 {1}</value>
   </data>
   <data name="Stats_SummaryPlaytime" xml:space="preserve">
-    <value>{0} played</value>
+    <value>{0} 已游玩</value>
   </data>
   <data name="Stats_SummaryAchievements" xml:space="preserve">
-    <value>{0} achievements</value>
+    <value>{0} 个成就</value>
   </data>
   <data name="Stats_SummaryStats" xml:space="preserve">
-    <value>{0} stats</value>
+    <value>{0} 项统计</value>
   </data>
   <data name="Nav_Settings" xml:space="preserve">
-    <value>Settings</value>
+    <value>设置</value>
   </data>
   <data name="Nav_RestartSteam" xml:space="preserve">
-    <value>Restart Steam</value>
+    <value>重启 Steam</value>
   </data>
   <data name="Nav_ChoiceMode" xml:space="preserve">
-    <value>Mode</value>
+    <value>模式</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- ChoiceModePage                                                      -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Choice_Title" xml:space="preserve">
-    <value>Choose Your Mode</value>
+    <value>选择您的模式</value>
   </data>
   <data name="Choice_Description" xml:space="preserve">
-    <value>Pick how you want to use CloudRedirect. You can switch between ST Fixer and Cloud Redirect anytime.</value>
+    <value>选择您想如何使用 CloudRedirect。您可以随时在 ST Fixer 和 Cloud Redirect 之间切换。</value>
   </data>
   <data name="Choice_STFixer_Title" xml:space="preserve">
-    <value>ST Fixer Mode</value>
+    <value>ST Fixer 模式</value>
   </data>
   <data name="Choice_STFixer_Description" xml:space="preserve">
-    <value>Just the core fixes. Solves saving issues with (not just) Capcom titles, fixes 'No Internet Connection' when downloading, enables manifest pinning, makes achievements work for every game that has them. Does not enable Cloud functionality.</value>
+    <value>仅核心修复。解决（不仅限于）Capcom 游戏的保存问题，修复下载时的"无互联网连接"，启用清单固定，使所有具有成就的游戏都能正常工作。不启用云功能。</value>
   </data>
   <data name="Choice_STFixer_Features" xml:space="preserve">
-    <value>Includes: Capcom save fix, SteamTools offline patch, DLL deploy, manifest version pinning</value>
+    <value>包括：Capcom 保存修复、SteamTools 离线补丁、DLL 部署、清单版本固定</value>
   </data>
   <data name="Choice_CloudRedirect_Title" xml:space="preserve">
-    <value>Cloud Redirect Mode</value>
+    <value>Cloud Redirect 模式</value>
   </data>
   <data name="Choice_CloudRedirect_Description" xml:space="preserve">
-    <value>Everything in ST Fixer, plus Cloud Save redirection. Redirects Steam Cloud for lua games to Google Drive/OneDrive/a local folder.</value>
+    <value>包含 ST Fixer 的所有功能，再加上云存档重定向。将 Lua 游戏的 Steam 云存档重定向到 Google Drive/OneDrive/本地文件夹。</value>
   </data>
   <data name="Choice_CloudRedirect_Features" xml:space="preserve">
-    <value>All ST Fixer features + Cloud Saves to your provider of choice + Achievement and Playtime Sync</value>
+    <value>所有 ST Fixer 功能 + 云存档到您选择的提供商 + 成就和游戏时长同步</value>
   </data>
   <data name="Choice_CurrentMode_STFixer" xml:space="preserve">
-    <value>Current mode: ST Fixer</value>
+    <value>当前模式：ST Fixer</value>
   </data>
   <data name="Choice_CurrentMode_STFixer_Desc" xml:space="preserve">
-    <value>You can switch to Cloud Redirect mode by selecting the option below. Cloud Redirect includes everything in ST Fixer plus cloud features. You can switch back anytime.</value>
+    <value>您可以通过选择下面的选项切换到 Cloud Redirect 模式。Cloud Redirect 包括 ST Fixer 中的所有内容以及云功能。您可以随时切换回来。</value>
   </data>
   <data name="Choice_CurrentMode_CloudRedirect" xml:space="preserve">
-    <value>Current mode: Cloud Redirect</value>
+    <value>当前模式：Cloud Redirect</value>
   </data>
   <data name="Choice_CurrentMode_CloudRedirect_Desc" xml:space="preserve">
-    <value>All features are enabled. Cloud save interception is active.</value>
+    <value>所有功能已启用。云存档拦截处于活动状态。</value>
   </data>
   <data name="Choice_ThirdParty_Title" xml:space="preserve">
-    <value>Third-Party Client Mode</value>
+    <value>第三方客户端模式</value>
   </data>
   <data name="Choice_ThirdParty_Description" xml:space="preserve">
-    <value>For use with OpenSteamTool, HubcapTools, or other third-party Steam clients that load CloudRedirect themselves. Only deploys the core DLL - no SteamTools patches.</value>
+    <value>与 OpenSteamTool、HubcapTools 或其他自行加载 CloudRedirect 的第三方 Steam 客户端一起使用。仅部署核心 DLL - 无 SteamTools 补丁。</value>
   </data>
   <data name="Choice_ThirdParty_Features" xml:space="preserve">
-    <value>Cloud Saves + Achievement/Playtime Sync (if supported by client) - no ST patching required</value>
+    <value>云存档 + 成就/游戏时长同步（如果客户端支持） - 无需 ST 补丁</value>
   </data>
   <data name="Choice_CurrentMode_ThirdParty" xml:space="preserve">
-    <value>Current mode: Third-Party Client</value>
+    <value>当前模式：第三方客户端</value>
   </data>
   <data name="Choice_CurrentMode_ThirdParty_Desc" xml:space="preserve">
-    <value>CloudRedirect is loaded by your third-party Steam client. Only the core DLL is deployed.</value>
+    <value>CloudRedirect 由您的第三方 Steam 客户端加载。仅部署核心 DLL。</value>
   </data>
   <data name="Choice_FailedSaveMode" xml:space="preserve">
-    <value>Couldn't save your selection: {0}</value>
+    <value>无法保存您的选择：{0}</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- SetupPage XAML                                                     -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Setup_Title" xml:space="preserve">
-    <value>Setup</value>
+    <value>设置</value>
   </data>
   <data name="Setup_Description" xml:space="preserve">
-    <value>Apply patches and deploy CloudRedirect to your Steam installation.</value>
+    <value>应用补丁并将 CloudRedirect 部署到您的 Steam 安装。</value>
   </data>
   <data name="Setup_Description_STFixer" xml:space="preserve">
-    <value>Apply patches for the Capcom save fix and manifest pinning.</value>
+    <value>为 Capcom 保存修复和清单固定应用补丁。</value>
   </data>
   <data name="Setup_Description_ThirdParty" xml:space="preserve">
-    <value>Deploy cloud_redirect.dll to your Steam folder. Your third-party client (OST, HubcapTools, etc.) will load it automatically - no other patches needed.</value>
+    <value>将 cloud_redirect.dll 部署到您的 Steam 文件夹。您的第三方客户端（OST、HubcapTools 等）将自动加载它 - 无需其他补丁。</value>
   </data>
   <data name="Setup_ConfirmDeployThirdParty" xml:space="preserve">
-    <value>This will deploy cloud_redirect.dll to your Steam directory. Your third-party client will load it on next launch. Continue?</value>
+    <value>这将把 cloud_redirect.dll 部署到您的 Steam 目录。您的第三方客户端将在下次启动时加载它。继续？</value>
   </data>
   <data name="Setup_ClientTypeHeader" xml:space="preserve">
-    <value>How does CloudRedirect get loaded?</value>
+    <value>CloudRedirect 如何加载？</value>
   </data>
   <data name="Setup_ClientType_ST" xml:space="preserve">
     <value>SteamTools</value>
   </data>
   <data name="Setup_ClientType_ST_Hint" xml:space="preserve">
-    <value>Full setup: patches Steam's DLLs and deploys the proxy. Use this if you don't have a third-party client.</value>
+    <value>完整设置：修补 Steam 的 DLL 并部署代理。如果您没有第三方客户端，请使用此选项。</value>
   </data>
   <data name="Setup_ClientType_ThirdParty" xml:space="preserve">
-    <value>I have an alternative, compatible unlock solution</value>
+    <value>我有一个替代的兼容解锁方案</value>
   </data>
   <data name="Setup_ClientType_NoClientWarning" xml:space="preserve">
-    <value>No compatible client detected in your Steam directory. Make sure your client is installed before launching Steam.</value>
+    <value>在您的 Steam 目录中未检测到兼容的客户端。在启动 Steam 之前确保已安装您的客户端。</value>
   </data>
   <data name="Setup_ShowDiagnostics" xml:space="preserve">
-    <value>Show Diagnostics</value>
+    <value>显示诊断</value>
   </data>
   <data name="Setup_ShowDiagnosticsHint" xml:space="preserve">
-    <value>Steam version, path, and individual patch controls</value>
+    <value>Steam 版本、路径和各个补丁控制</value>
   </data>
   <data name="Setup_SteamVersion" xml:space="preserve">
-    <value>Steam Version</value>
+    <value>Steam 版本</value>
   </data>
   <data name="Setup_Checking" xml:space="preserve">
-    <value>Checking...</value>
+    <value>检查中...</value>
   </data>
   <data name="Setup_SteamPath" xml:space="preserve">
-    <value>Steam Path</value>
+    <value>Steam 路径</value>
   </data>
   <data name="Setup_Detecting" xml:space="preserve">
-    <value>Detecting...</value>
+    <value>检测中...</value>
   </data>
   <data name="Setup_Change" xml:space="preserve">
-    <value>Change</value>
+    <value>更改</value>
   </data>
   <data name="Setup_RunAllPatches" xml:space="preserve">
-    <value>Run All Patches</value>
+    <value>运行所有补丁</value>
   </data>
   <data name="Setup_OfflineSetupHeader" xml:space="preserve">
-    <value>SteamTools Offline Setup</value>
+    <value>SteamTools 离线设置</value>
   </data>
   <data name="Setup_OfflineSetupDescription" xml:space="preserve">
-    <value>Patches SteamTools so it works even when their activation servers are down. Required for first-time installations.</value>
+    <value>修补 SteamTools，使其即使在激活服务器停机时也能正常工作。首次安装必需。</value>
   </data>
   <data name="Setup_OfflineSetup" xml:space="preserve">
-    <value>Offline Setup</value>
+    <value>离线设置</value>
   </data>
   <data name="Setup_NotChecked" xml:space="preserve">
-    <value>Not checked</value>
+    <value>未检查</value>
   </data>
   <data name="Setup_ApplyOfflineSetup" xml:space="preserve">
-    <value>Apply Offline Setup</value>
+    <value>应用离线设置</value>
   </data>
   <data name="Setup_RevertPatch" xml:space="preserve">
-    <value>Revert Patch</value>
+    <value>还原补丁</value>
   </data>
   <data name="Setup_StExeHeader" xml:space="preserve">
-    <value>SteamTools.exe Patch</value>
+    <value>SteamTools.exe 补丁</value>
   </data>
   <data name="Setup_StExeDescription" xml:space="preserve">
-    <value>Disables the SteamTools Desktop App from overwriting patched DLLs on every startup. Without this, SteamTools will undo core patches.</value>
+    <value>禁止 SteamTools 桌面应用在每次启动时覆盖已打补丁的 DLL。如果没有这个，SteamTools 将撤消核心补丁。</value>
   </data>
   <data name="Setup_DllDeploy" xml:space="preserve">
-    <value>DLL Deploy</value>
+    <value>DLL 部署</value>
   </data>
   <data name="Setup_PatchSteamToolsExe" xml:space="preserve">
-    <value>Patch SteamTools.exe</value>
+    <value>修补 SteamTools.exe</value>
   </data>
   <data name="Setup_CloudRedirectPatchHeader" xml:space="preserve">
-    <value>Cloud Redirect Patch</value>
+    <value>Cloud Redirect 补丁</value>
   </data>
   <data name="Setup_CloudRedirectPatchHeader_STFixer" xml:space="preserve">
-    <value>Save Fix and Manifest Pinning Patch</value>
+    <value>保存修复和清单固定补丁</value>
   </data>
   <data name="Setup_CloudRedirectPatchDescription" xml:space="preserve">
-    <value>Patches SteamTools payload so lua app cloud saves are routed through the CloudRedirect system.</value>
+    <value>修补 SteamTools 有效载荷，使 Lua 应用的云存档通过 CloudRedirect 系统路由。</value>
   </data>
   <data name="Setup_CloudRedirectPatchDescription_STFixer" xml:space="preserve">
-    <value>Patches SteamTools payload to fix Capcom save routing and enable manifest pinning for lua apps.</value>
+    <value>修补 SteamTools 有效载荷以修复 Capcom 保存路由并为 Lua 应用启用清单固定。</value>
   </data>
   <data name="Setup_PatchStatus" xml:space="preserve">
-    <value>Patch Status</value>
+    <value>补丁状态</value>
   </data>
   <data name="Setup_ApplyPatch" xml:space="preserve">
-    <value>Apply Patch</value>
+    <value>应用补丁</value>
   </data>
   <data name="Setup_DeployHeader" xml:space="preserve">
-    <value>Deploy CloudRedirect</value>
+    <value>部署 CloudRedirect</value>
   </data>
   <data name="Setup_DeployDescription" xml:space="preserve">
-    <value>Copies core DLL to your Steam folder.</value>
+    <value>将核心 DLL 复制到您的 Steam 文件夹。</value>
   </data>
   <data name="Setup_DllStatus" xml:space="preserve">
-    <value>DLL Status</value>
+    <value>DLL 状态</value>
   </data>
   <data name="Setup_DeployDll" xml:space="preserve">
-    <value>Deploy DLL</value>
+    <value>部署 DLL</value>
   </data>
   <data name="Setup_UninstallDll" xml:space="preserve">
-    <value>Uninstall DLL</value>
+    <value>卸载 DLL</value>
   </data>
   <data name="Setup_LogOutput" xml:space="preserve">
-    <value>Log Output</value>
+    <value>日志输出</value>
   </data>
   <data name="Setup_Ready" xml:space="preserve">
-    <value>Ready.</value>
+    <value>就绪。</value>
   </data>
 
   <!-- SetupPage code-behind -->
   <data name="Setup_SteamNotFoundManual" xml:space="preserve">
-    <value>Not found - click Change to set manually</value>
+    <value>未找到 - 点击"更改"手动设置</value>
   </data>
   <data name="Setup_SteamNotFound" xml:space="preserve">
-    <value>Steam not found</value>
+    <value>未找到 Steam</value>
   </data>
   <data name="Setup_VersionCouldNotDetermine" xml:space="preserve">
-    <value>Could not determine Steam version</value>
+    <value>无法确定 Steam 版本</value>
   </data>
   <data name="Setup_VersionSupported" xml:space="preserve">
-    <value>{0} (supported)</value>
+    <value>{0}（支持）</value>
   </data>
   <data name="Setup_VersionUnsupported" xml:space="preserve">
-    <value>{0} (UNSUPPORTED - {1} than expected {2})</value>
+    <value>{0}（不支持 - 比预期的 {2} {1}）</value>
   </data>
   <data name="Setup_DirectionNewer" xml:space="preserve">
-    <value>newer</value>
+    <value>更新</value>
   </data>
   <data name="Setup_DirectionOlder" xml:space="preserve">
-    <value>older</value>
+    <value>更旧</value>
   </data>
   <data name="Setup_PatchState_Patched" xml:space="preserve">
-    <value>Patched</value>
+    <value>已打补丁</value>
   </data>
   <data name="Setup_PatchState_Unpatched" xml:space="preserve">
-    <value>Not patched</value>
+    <value>未打补丁</value>
   </data>
   <data name="Setup_PatchState_PartiallyPatched" xml:space="preserve">
-    <value>Partially patched</value>
+    <value>部分打补丁</value>
   </data>
   <data name="Setup_PatchState_NotInstalled" xml:space="preserve">
-    <value>SteamTools not installed</value>
+    <value>未安装 SteamTools</value>
   </data>
   <data name="Setup_PatchState_UnknownVersion" xml:space="preserve">
-    <value>Unknown version</value>
+    <value>未知版本</value>
   </data>
   <data name="Setup_PatchState_OutOfDate" xml:space="preserve">
-    <value>Out of date</value>
+    <value>已过期</value>
   </data>
   <data name="Setup_PatchState_Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="Setup_OfflinePatched" xml:space="preserve">
-    <value>Patched (offline mode enabled)</value>
+    <value>已打补丁（离线模式已启用）</value>
   </data>
   <data name="Setup_StExePatched" xml:space="preserve">
-    <value>Patched (DLL deploy disabled)</value>
+    <value>已打补丁（DLL 部署已禁用）</value>
   </data>
   <data name="Setup_StExeActive" xml:space="preserve">
-    <value>Active - will overwrite patched DLLs!</value>
+    <value>活动 - 将覆盖已打补丁的 DLL！</value>
   </data>
   <data name="Setup_StExeNotFound" xml:space="preserve">
-    <value>SteamTools Desktop not found</value>
+    <value>未找到 SteamTools 桌面版</value>
   </data>
   <data name="Setup_CouldNotCheck" xml:space="preserve">
-    <value>Could not check: {0}</value>
+    <value>无法检查：{0}</value>
   </data>
   <data name="Setup_DllInstalledOutdated" xml:space="preserve">
-    <value>Installed but outdated ({0}) - update available</value>
+    <value>已安装但已过期（{0}） - 可更新</value>
   </data>
   <data name="Setup_DllInstalled" xml:space="preserve">
-    <value>Installed ({0} bytes, {1})</value>
+    <value>已安装（{0} 字节，{1}）</value>
   </data>
   <data name="Setup_UpdateDll" xml:space="preserve">
-    <value>Update DLL</value>
+    <value>更新 DLL</value>
   </data>
   <data name="Setup_Deploy" xml:space="preserve">
-    <value>Deploy</value>
+    <value>部署</value>
   </data>
   <data name="Setup_DllNotInstalledReady" xml:space="preserve">
-    <value>Not installed - ready to deploy</value>
+    <value>未安装 - 准备部署</value>
   </data>
   <data name="Setup_DllNotInstalledNoEmbed" xml:space="preserve">
-    <value>Not installed - DLL not embedded in this build</value>
+    <value>未安装 - DLL 未嵌入此构建</value>
   </data>
   <data name="Setup_InvalidSteamFolder" xml:space="preserve">
-    <value>Invalid Steam Folder</value>
+    <value>无效的 Steam 文件夹</value>
   </data>
   <data name="Setup_BrowseSteamFolderTitle" xml:space="preserve">
-    <value>Select Steam installation folder</value>
+    <value>选择 Steam 安装文件夹</value>
   </data>
   <data name="Setup_InvalidSteamFolderMessage" xml:space="preserve">
-    <value>The selected folder doesn't contain steam.exe.
+    <value>所选文件夹不包含 steam.exe。
 
-Please select the folder where Steam is installed.</value>
+请选择 Steam 的安装文件夹。</value>
   </data>
   <data name="Setup_PatchAppliedSuccessfully" xml:space="preserve">
-    <value>Patch applied successfully</value>
+    <value>补丁应用成功</value>
   </data>
   <data name="Setup_PatchFailedSeeLog" xml:space="preserve">
-    <value>Patch failed - see log</value>
+    <value>补丁失败 - 请查看日志</value>
   </data>
   <data name="Setup_FailedSeeLog" xml:space="preserve">
-    <value>Failed - see log</value>
+    <value>失败 - 请查看日志</value>
   </data>
   <data name="Setup_DeployFailed" xml:space="preserve">
-    <value>Deploy failed</value>
+    <value>部署失败</value>
   </data>
   <data name="Setup_NotInstalled" xml:space="preserve">
-    <value>Not installed</value>
+    <value>未安装</value>
   </data>
   <data name="Setup_UninstallFailedSteam" xml:space="preserve">
-    <value>Uninstall failed - is Steam running?</value>
+    <value>卸载失败 - Steam 是否正在运行？</value>
   </data>
   <data name="Setup_DllNotEmbedded" xml:space="preserve">
-    <value>Not Found</value>
+    <value>未找到</value>
   </data>
   <data name="Setup_DllNotEmbeddedMessage" xml:space="preserve">
-    <value>cloud_redirect.dll is not embedded in this build.
+    <value>cloud_redirect.dll 未嵌入此构建。
 
-Rebuild the UI after building the C++ DLL.</value>
+在构建 C++ DLL 后重新构建 UI。</value>
   </data>
   <data name="Setup_ConfirmRunAll" xml:space="preserve">
-    <value>This will apply all patches and deploy the DLL:
+    <value>这将应用所有补丁并部署 DLL：
 
-  1. SteamTools Offline Setup
-  2. Patch SteamTools.exe
-  3. Cloud Redirect Patch
-  4. Deploy cloud_redirect.dll
+  1. SteamTools 离线设置
+  2. 修补 SteamTools.exe
+  3. Cloud Redirect 补丁
+  4. 部署 cloud_redirect.dll
 
-If Steam is running, it will be closed automatically.
-Backups will be created.
+如果 Steam 正在运行，它将自动关闭。
+将创建备份。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Setup_ConfirmOfflineSetup" xml:space="preserve">
-    <value>This patches SteamTools so it works even when their activation
-servers are down.
+    <value>这将修补 SteamTools，使其即使在激活服务器停机时也能正常工作。
 
-If Steam is running, it will be closed automatically.
-A backup will be created.
+如果 Steam 正在运行，它将自动关闭。
+将创建备份。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Setup_ConfirmRevertOffline" xml:space="preserve">
-    <value>This will revert the offline setup patch, restoring
-original SteamTools activation behavior.
+    <value>这将还原离线设置补丁，恢复原始的 SteamTools 激活行为。
 
-If Steam is running, it will be closed automatically.
+如果 Steam 正在运行，它将自动关闭。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Setup_ConfirmPatchStExe" xml:space="preserve">
-    <value>This patches SteamTools.exe to stop it from overwriting
-patched DLLs on every startup.
+    <value>这将修补 SteamTools.exe，使其停止在每次启动时覆盖已打补丁的 DLL。
 
-If Steam is running, it will be closed automatically.
-A backup will be created.
+如果 Steam 正在运行，它将自动关闭。
+将创建备份。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Setup_ConfirmRevertStExe" xml:space="preserve">
-    <value>This will restore SteamTools.exe to its original state,
-allowing it to overwrite DLLs on startup again.
+    <value>这将恢复 SteamTools.exe 到其原始状态，允许它在启动时再次覆盖 DLL。
 
-If Steam is running, it will be closed automatically.
+如果 Steam 正在运行，它将自动关闭。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Setup_ConfirmApplyPatch" xml:space="preserve">
-    <value>This will patch steamclient64.dll to redirect cloud RPCs.
+    <value>这将修补 steamclient64.dll 以重定向云 RPC。
 
-If Steam is running, it will be closed automatically.
-A backup will be created.
+如果 Steam 正在运行，它将自动关闭。
+将创建备份。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Setup_ConfirmRevertPatch" xml:space="preserve">
-    <value>This will revert the cloud redirect patch on
-steamclient64.dll, restoring original behavior.
+    <value>这将还原 steamclient64.dll 上的云重定向补丁，恢复原始行为。
 
-If Steam is running, it will be closed automatically.
+如果 Steam 正在运行，它将自动关闭。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Setup_ConfirmDeploy" xml:space="preserve">
-    <value>This will deploy cloud_redirect.dll to your Steam folder.
+    <value>这将把 cloud_redirect.dll 部署到您的 Steam 文件夹。
 
-If Steam is running, it will be closed automatically.
+如果 Steam 正在运行，它将自动关闭。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Setup_ConfirmUninstall" xml:space="preserve">
-    <value>This will delete cloud_redirect.dll from your Steam folder.
+    <value>这将从您的 Steam 文件夹中删除 cloud_redirect.dll。
 
-If Steam is running, it will be closed automatically.
+如果 Steam 正在运行，它将自动关闭。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Setup_ConfigureProviderTitle" xml:space="preserve">
-    <value>Configure Cloud Provider</value>
+    <value>配置云存储提供商</value>
   </data>
   <data name="Setup_ConfigureProviderExisting" xml:space="preserve">
     <value>{0}
 
-Current cloud provider: {1}
+当前云存储提供商：{1}
 
-Would you like to review or change your cloud provider settings?</value>
+您想查看或更改您的云存储提供商设置吗？</value>
   </data>
   <data name="Setup_ConfigureProviderNew" xml:space="preserve">
     <value>{0}
 
-Would you like to set up a cloud provider (Google Drive, OneDrive, or a network folder) to sync your saves?
+您想设置云存储提供商（Google Drive、OneDrive 或本地文件夹）来同步您的存档吗？
 
-If you skip this, saves will be stored locally in your Steam folder.</value>
+如果跳过此步骤，存档将本地存储在您的 Steam 文件夹中。</value>
   </data>
   <data name="Setup_AllPatchesApplied" xml:space="preserve">
-    <value>All patches applied successfully!</value>
+    <value>所有补丁应用成功！</value>
   </data>
   <data name="Setup_PatchingFinishedWithErrors" xml:space="preserve">
-    <value>Patching finished (some steps failed - see log).</value>
+    <value>补丁完成（某些步骤失败 - 请查看日志）。</value>
   </data>
   <data name="Setup_ConfigureProvider" xml:space="preserve">
-    <value>Configure Provider</value>
+    <value>配置提供商</value>
   </data>
   <data name="Setup_UseLocalStorage" xml:space="preserve">
-    <value>Use Local Storage</value>
+    <value>使用本地存储</value>
   </data>
   <data name="Setup_ConfirmOfflineSetupTitle" xml:space="preserve">
-    <value>SteamTools Offline Setup</value>
+    <value>SteamTools 离线设置</value>
   </data>
   <data name="Setup_RevertOfflineSetupTitle" xml:space="preserve">
-    <value>Revert Offline Setup</value>
+    <value>还原离线设置</value>
   </data>
   <data name="Setup_PatchSteamToolsExeTitle" xml:space="preserve">
-    <value>Patch SteamTools.exe</value>
+    <value>修补 SteamTools.exe</value>
   </data>
   <data name="Setup_RevertStExeTitle" xml:space="preserve">
-    <value>Revert SteamTools.exe Patch</value>
+    <value>还原 SteamTools.exe 补丁</value>
   </data>
   <data name="Setup_ApplyPatchTitle" xml:space="preserve">
-    <value>Apply Patch</value>
+    <value>应用补丁</value>
   </data>
   <data name="Setup_RevertCloudRedirectTitle" xml:space="preserve">
-    <value>Revert Cloud Redirect Patch</value>
+    <value>还原 Cloud Redirect 补丁</value>
   </data>
   <data name="Setup_DeployDllTitle" xml:space="preserve">
-    <value>Deploy DLL</value>
+    <value>部署 DLL</value>
   </data>
   <data name="Setup_UninstallDllTitle" xml:space="preserve">
-    <value>Uninstall DLL</value>
+    <value>卸载 DLL</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- DashboardPage XAML                                                 -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Dashboard_Title" xml:space="preserve">
-    <value>Dashboard</value>
+    <value>仪表板</value>
   </data>
   <data name="Dashboard_UpdateNow" xml:space="preserve">
-    <value>Update Now</value>
+    <value>立即更新</value>
   </data>
   <data name="Dashboard_UpdateAvailable" xml:space="preserve">
-    <value>Update Available</value>
+    <value>可用更新</value>
   </data>
   <data name="Dashboard_UpdateAvailableDescription" xml:space="preserve">
-    <value>A newer version of the CloudRedirect DLL is available. Please update.</value>
+    <value>CloudRedirect DLL 有新版本可用。请更新。</value>
   </data>
   <data name="Dashboard_CloudProvider" xml:space="preserve">
-    <value>Cloud Provider</value>
+    <value>云存储提供商</value>
   </data>
   <data name="Dashboard_NotConfigured" xml:space="preserve">
-    <value>Not configured</value>
+    <value>未配置</value>
   </data>
   <data name="Dashboard_SteamInstallation" xml:space="preserve">
-    <value>Steam Installation</value>
+    <value>Steam 安装</value>
   </data>
   <data name="Dashboard_Detecting" xml:space="preserve">
-    <value>Detecting...</value>
+    <value>检测中...</value>
   </data>
   <data name="Dashboard_AppsSyncing" xml:space="preserve">
-    <value>Apps Syncing</value>
+    <value>同步的应用</value>
   </data>
   <data name="Dashboard_AppCountDefault" xml:space="preserve">
-    <value>0 apps configured</value>
+    <value>0 个已配置的应用</value>
   </data>
   <data name="Dashboard_CloudRedirectDll" xml:space="preserve">
     <value>CloudRedirect DLL</value>
   </data>
   <data name="Dashboard_DllChecking" xml:space="preserve">
-    <value>Checking...</value>
+    <value>检查中...</value>
   </data>
   <data name="Dashboard_QuickActions" xml:space="preserve">
-    <value>Quick Actions</value>
+    <value>快速操作</value>
   </data>
-
   <data name="Dashboard_OpenLogFile" xml:space="preserve">
-    <value>Show Log in Folder</value>
+    <value>在文件夹中显示日志</value>
   </data>
   <data name="Dashboard_RestartSteam" xml:space="preserve">
-    <value>Restart Steam</value>
+    <value>重启 Steam</value>
   </data>
 
   <!-- DashboardPage code-behind -->
   <data name="Dashboard_NotFound" xml:space="preserve">
-    <value>Not found</value>
+    <value>未找到</value>
   </data>
   <data name="Dashboard_DllNotInstalled" xml:space="preserve">
-    <value>Not installed</value>
+    <value>未安装</value>
   </data>
   <data name="Dashboard_DllInstalledUpdateAvailable" xml:space="preserve">
-    <value>Installed (update available)</value>
+    <value>已安装（可更新）</value>
   </data>
   <data name="Dashboard_DllInstalled" xml:space="preserve">
-    <value>Installed</value>
+    <value>已安装</value>
   </data>
   <data name="Dashboard_AppCountFormat" xml:space="preserve">
-    <value>{0} app(s) with cloud data</value>
+    <value>{0} 个有云数据的应用</value>
   </data>
   <data name="Dashboard_FolderAccessible" xml:space="preserve">
-    <value>{0} - Folder accessible</value>
+    <value>{0} - 文件夹可访问</value>
   </data>
   <data name="Dashboard_FolderNotFound" xml:space="preserve">
-    <value>{0} - Folder not found</value>
+    <value>{0} - 未找到文件夹</value>
   </data>
   <data name="Dashboard_NoSyncFolder" xml:space="preserve">
-    <value>{0} - No sync folder configured</value>
+    <value>{0} - 未配置同步文件夹</value>
   </data>
   <data name="Dashboard_Authenticated" xml:space="preserve">
-    <value>{0} - Authenticated</value>
+    <value>{0} - 已认证</value>
   </data>
   <data name="Dashboard_AuthStatus" xml:space="preserve">
     <value>{0} - {1}</value>
   </data>
   <data name="Dashboard_NoTokenPath" xml:space="preserve">
-    <value>{0} - No token path configured</value>
+    <value>{0} - 未配置令牌路径</value>
   </data>
   <data name="Dashboard_LogNotFound" xml:space="preserve">
-    <value>Log file not found. Start Steam with CloudRedirect installed first.</value>
+    <value>未找到日志文件。请先启动已安装 CloudRedirect 的 Steam。</value>
   </data>
   <data name="Dashboard_ClosingSteam" xml:space="preserve">
-    <value>Closing Steam...</value>
+    <value>关闭 Steam...</value>
   </data>
   <data name="Dashboard_Updating" xml:space="preserve">
-    <value>Updating...</value>
+    <value>更新中...</value>
   </data>
   <data name="Dashboard_UpdateFailed" xml:space="preserve">
-    <value>Update failed</value>
+    <value>更新失败</value>
   </data>
   <data name="Dashboard_DllInstalledUpdated" xml:space="preserve">
-    <value>Installed (updated)</value>
+    <value>已安装（已更新）</value>
   </data>
   <data name="Dashboard_DllUpdatedTitle" xml:space="preserve">
-    <value>DLL Updated</value>
+    <value>DLL 已更新</value>
   </data>
   <data name="Dashboard_DllUpdatedRestartPrompt" xml:space="preserve">
-    <value>cloud_redirect.dll has been updated.
+    <value>cloud_redirect.dll 已更新。
 
-Restart Steam now?</value>
+现在重启 Steam？</value>
   </data>
   <data name="Dashboard_FailedUpdateDll" xml:space="preserve">
-    <value>Failed to update DLL: {0}</value>
+    <value>无法更新 DLL：{0}</value>
   </data>
   <data name="Dashboard_RestartSteamPrompt" xml:space="preserve">
-    <value>This will shut down Steam and restart it.
-Continue?</value>
+    <value>这将关闭并重启 Steam。
+继续？</value>
   </data>
   <data name="Dashboard_ShuttingDownSteam" xml:space="preserve">
-    <value>Shutting down Steam...</value>
+    <value>关闭 Steam...</value>
   </data>
   <data name="Dashboard_SteamStillRunning" xml:space="preserve">
-    <value>Steam still running</value>
+    <value>Steam 仍在运行</value>
   </data>
   <data name="Dashboard_SteamStillRunningPrompt" xml:space="preserve">
-    <value>Steam did not shut down within 15 seconds.
-Force-kill it?</value>
+    <value>Steam 在 15 秒内未关闭。
+强制终止它？</value>
   </data>
   <data name="Dashboard_ForceKilling" xml:space="preserve">
-    <value>Force-killing Steam...</value>
+    <value>强制终止 Steam...</value>
   </data>
   <data name="Dashboard_StartingSteam" xml:space="preserve">
-    <value>Starting Steam...</value>
+    <value>启动 Steam...</value>
   </data>
   <data name="Dashboard_FailedRestartSteam" xml:space="preserve">
-    <value>Failed to restart Steam: {0}</value>
+    <value>无法重启 Steam：{0}</value>
   </data>
   <data name="Dashboard_SteamExeNotFound" xml:space="preserve">
-    <value>steam.exe not found.</value>
+    <value>未找到 steam.exe。</value>
   </data>
   <data name="Dashboard_CouldNotFindSteam" xml:space="preserve">
-    <value>Could not find Steam installation.</value>
+    <value>无法找到 Steam 安装。</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- CloudProviderPage XAML                                             -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="CloudProvider_Title" xml:space="preserve">
-    <value>Cloud Provider</value>
+    <value>云存储提供商</value>
   </data>
   <data name="CloudProvider_Description" xml:space="preserve">
-    <value>Configure your Steam Cloud provider. Google Drive/OneDrive/Local Folder only for now.</value>
+    <value>配置您的 Steam 云提供商。目前仅支持 Google Drive/OneDrive/本地文件夹。</value>
   </data>
   <data name="CloudProvider_Provider" xml:space="preserve">
-    <value>Provider</value>
+    <value>提供商</value>
   </data>
   <data name="CloudProvider_GoogleDrive" xml:space="preserve">
     <value>Google Drive</value>
@@ -731,683 +725,690 @@ Force-kill it?</value>
     <value>OneDrive</value>
   </data>
   <data name="CloudProvider_FolderMappedDrive" xml:space="preserve">
-    <value>Folder / Mapped Drive</value>
+    <value>文件夹 / 映射驱动器</value>
   </data>
   <data name="CloudProvider_LocalOnly" xml:space="preserve">
-    <value>Local only (no cloud sync)</value>
+    <value>仅本地（无云同步）</value>
   </data>
   <data name="CloudProvider_TokenFilePath" xml:space="preserve">
-    <value>Token File Path</value>
+    <value>令牌文件路径</value>
   </data>
   <data name="CloudProvider_TokenPlaceholder" xml:space="preserve">
-    <value>Path to OAuth tokens file</value>
+    <value>OAuth 令牌文件的路径</value>
   </data>
   <data name="CloudProvider_Browse" xml:space="preserve">
-    <value>Browse</value>
+    <value>浏览</value>
   </data>
   <data name="CloudProvider_Authentication" xml:space="preserve">
-    <value>Authentication</value>
+    <value>身份验证</value>
   </data>
   <data name="CloudProvider_AuthenticationStatus" xml:space="preserve">
-    <value>Authentication Status</value>
+    <value>身份验证状态</value>
   </data>
   <data name="CloudProvider_NoTokensLoaded" xml:space="preserve">
-    <value>No tokens loaded</value>
+    <value>未加载令牌</value>
   </data>
   <data name="CloudProvider_SignIn" xml:space="preserve">
-    <value>Sign In</value>
+    <value>登录</value>
   </data>
   <data name="CloudProvider_Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>取消</value>
   </data>
 
   <!-- CloudProviderPage code-behind -->
   <data name="CloudProvider_NoConfigFound" xml:space="preserve">
-    <value>No config.json found - using defaults</value>
+    <value>未找到 config.json - 使用默认值</value>
   </data>
   <data name="CloudProvider_ErrorReadingConfig" xml:space="preserve">
-    <value>Error reading config: {0}</value>
+    <value>读取配置时出错：{0}</value>
   </data>
   <data name="CloudProvider_SyncFolderPath" xml:space="preserve">
-    <value>Sync Folder Path</value>
+    <value>同步文件夹路径</value>
   </data>
   <data name="CloudProvider_SyncFolderPlaceholder" xml:space="preserve">
-    <value>Path to sync folder (e.g. Z:\CloudRedirect)</value>
+    <value>同步文件夹的路径（例如 Z:\CloudRedirect）</value>
   </data>
   <data name="CloudProvider_SyncFolderHint" xml:space="preserve">
-    <value>Choose any folder - including a mapped network drive, USB drive, or NAS share.</value>
+    <value>选择任何文件夹 - 包括映射的网络驱动器、USB 驱动器或 NAS 共享。</value>
   </data>
   <data name="CloudProvider_LocalStoragePath" xml:space="preserve">
-    <value>Local Storage Path</value>
+    <value>本地存储路径</value>
   </data>
   <data name="CloudProvider_LocalStorageHint" xml:space="preserve">
-    <value>Saves are stored locally in your Steam folder. No cloud sync.</value>
+    <value>存档本地存储在您的 Steam 文件夹中。无云同步。</value>
   </data>
   <data name="CloudProvider_SelectSyncFolder" xml:space="preserve">
-    <value>Select sync folder</value>
+    <value>选择同步文件夹</value>
   </data>
   <data name="CloudProvider_SelectTokenFile" xml:space="preserve">
-    <value>Select OAuth Token File</value>
+    <value>选择 OAuth 令牌文件</value>
   </data>
   <data name="CloudProvider_MissingPath" xml:space="preserve">
-    <value>Missing Path</value>
+    <value>缺少路径</value>
   </data>
   <data name="CloudProvider_MissingPathMessage" xml:space="preserve">
-    <value>Please set a token file path first.</value>
+    <value>请先设置令牌文件路径。</value>
   </data>
   <data name="CloudProvider_FailedSaveConfig" xml:space="preserve">
-    <value>Failed to save config: {0}</value>
+    <value>无法保存配置：{0}</value>
   </data>
   <data name="CloudProvider_LocalModeStored" xml:space="preserve">
-    <value>Local mode - saves stored in: {0}</value>
+    <value>本地模式 - 存档存储在：{0}</value>
   </data>
   <data name="CloudProvider_LocalModeNoSync" xml:space="preserve">
-    <value>Local mode - no cloud sync</value>
+    <value>本地模式 - 无云同步</value>
   </data>
   <data name="CloudProvider_NoSyncFolder" xml:space="preserve">
-    <value>No sync folder specified</value>
+    <value>未指定同步文件夹</value>
   </data>
   <data name="CloudProvider_FolderAccessible" xml:space="preserve">
-    <value>Folder accessible: {0}</value>
+    <value>文件夹可访问：{0}</value>
   </data>
   <data name="CloudProvider_FolderNotFound" xml:space="preserve">
-    <value>Folder not found: {0}</value>
+    <value>未找到文件夹：{0}</value>
   </data>
   <data name="CloudProvider_NoTokenFilePath" xml:space="preserve">
-    <value>No token file path specified</value>
+    <value>未指定令牌文件路径</value>
+  </data>
+  <data name="CloudProvider_UploadInFlight" xml:space="preserve">
+    <value>并发上传大小</value>
+  </data>
+  <data name="CloudProvider_UploadInFlightHint" xml:space="preserve">
+    <value>控制并发上传的最大文件大小。增加不会加快加载速度，但增加它可能导致多个大型存档上传失败。不建议更改。仅在知道自己在做什么时才更改。</value>
+  </data>
+  <data name="CloudProvider_UploadInFlightValue" xml:space="preserve">
+    <value>{0} MB</value>
+  </data>
+  <data name="CloudProvider_UploadInFlightConservative" xml:space="preserve">
+    <value>安全 (24)</value>
+  </data>
+  <data name="CloudProvider_UploadInFlightBalanced" xml:space="preserve">
+    <value>平衡 (44)</value>
+  </data>
+  <data name="CloudProvider_UploadInFlightAggressive" xml:space="preserve">
+    <value>激进 (64)</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- AppsPage XAML                                                      -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Apps_Title" xml:space="preserve">
-    <value>Apps</value>
+    <value>应用</value>
   </data>
   <data name="Apps_Description" xml:space="preserve">
-    <value>Cloud save data for your injected apps.</value>
+    <value>您已注入应用的云存档数据。</value>
   </data>
   <data name="Apps_RestoreSaves" xml:space="preserve">
-    <value>Restore Saves</value>
+    <value>恢复存档</value>
   </data>
   <data name="Apps_Files" xml:space="preserve">
-    <value>files</value>
+    <value>个文件</value>
   </data>
   <data name="Apps_ChangeNumber" xml:space="preserve">
-    <value>CN:</value>
+    <value>变更号：</value>
   </data>
   <data name="Apps_DeleteTooltip" xml:space="preserve">
-    <value>Delete all saves for this app</value>
+    <value>删除此应用的所有存档</value>
   </data>
   <data name="Apps_Back" xml:space="preserve">
-    <value>Back</value>
+    <value>返回</value>
   </data>
   <data name="Apps_Refresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>刷新</value>
   </data>
   <data name="Apps_RestoreDescription" xml:space="preserve">
-    <value>Restore files from a previous delete backup. Each delete creates an immutable, timestamped backup. Restoring copies files back without modifying the backup.</value>
+    <value>从以前的删除备份中恢复文件。每次删除都会创建一个不可变的、带时间戳的备份。恢复会将文件复制回来而不修改备份。</value>
   </data>
   <data name="Apps_LoadingBackups" xml:space="preserve">
-    <value>Loading backups...</value>
+    <value>加载备份中...</value>
   </data>
-
-  <!-- AppsPage code-behind -->
   <data name="Apps_DeleteAllSavesTitle" xml:space="preserve">
-    <value>Delete All Saves</value>
+    <value>删除所有存档</value>
   </data>
   <data name="Apps_DeletePromptHeader" xml:space="preserve">
-    <value>Delete all save data for {0} ({1})?
+    <value>删除 {0} ({1}) 的所有存档数据？
 
 </value>
   </data>
   <data name="Apps_DeletePromptWillDelete" xml:space="preserve">
-    <value>This will </value>
+    <value>这将</value>
   </data>
   <data name="Apps_DeletePromptDelete" xml:space="preserve">
-    <value>delete</value>
+    <value>删除</value>
   </data>
   <data name="Apps_DeletePromptLocalStorage" xml:space="preserve">
-    <value>  - CloudRedirect local storage: {0} file(s) ({1})
+    <value>  - CloudRedirect 本地存储：{0} 个文件（{1}）
 </value>
   </data>
   <data name="Apps_DeletePromptCloudCopies" xml:space="preserve">
-    <value>Cloud copies on {0}</value>
+    <value>{0} 上的云副本</value>
   </data>
   <data name="Apps_DeletePromptUserdata" xml:space="preserve">
-    <value>  - Steam userdata: {0}
+    <value>  - Steam 用户数据：{0}
 </value>
   </data>
   <data name="Apps_DeletePromptGameSaves" xml:space="preserve">
-    <value>  - Game saves: {0}
+    <value>  - 游戏存档：{0}
 </value>
   </data>
   <data name="Apps_DeletePromptSkipped" xml:space="preserve">
     <value>
-  (Skipped {0} path(s) that could not be resolved: {1})
+  （跳过 {0} 个无法解析的路径：{1}）
 </value>
   </data>
   <data name="Apps_DeletePromptWarning" xml:space="preserve">
-    <value>This will delete your saves.</value>
+    <value>这将删除您的存档。</value>
   </data>
   <data name="Apps_DeletePromptExplanation" xml:space="preserve">
-    <value>Local saves will be backed up, but restoring them is complex. You would have to disable cloud storage for the game in Steam, restore the backup, and then launch the game. If you continue, your cloud saves will be lost. Those are not backed up.</value>
+    <value>本地存档将被备份，但恢复它们很复杂。您必须在 Steam 中禁用游戏的云存储，恢复备份，然后启动游戏。如果继续，您的云存档将丢失。这些不会被备份。</value>
   </data>
   <data name="Apps_DeletePromptConsequence" xml:space="preserve">
-    <value>If you continue, the game will behave as if you never played it. You will start the game from the beginning on next launch.</value>
+    <value>如果继续，游戏的表现就像您从未玩过一样。您将在下次启动时从头开始游戏。</value>
   </data>
   <data name="Apps_DeletePromptBeSure" xml:space="preserve">
-    <value>Be Sure.</value>
+    <value>请确认。</value>
   </data>
   <data name="Apps_FinalConfirmTitle" xml:space="preserve">
-    <value>Final Confirmation</value>
+    <value>最终确认</value>
   </data>
   <data name="Apps_FinalConfirmMessage" xml:space="preserve">
-    <value>This will delete all save data for {0} ({1}).
+    <value>这将删除 {0} ({1}) 的所有存档数据。
 
-Local saves will be backed up, but cloud copies will be permanently lost. Restoring saves is tricky.
+本地存档将被备份，但云副本将永久丢失。恢复存档很棘手。
 
-Are you sure?</value>
+您确定吗？</value>
   </data>
   <data name="Apps_PartialDeleteTitle" xml:space="preserve">
-    <value>Partial Delete</value>
+    <value>部分删除</value>
   </data>
   <data name="Apps_PartialDeleteMessage" xml:space="preserve">
-    <value>Some data could not be deleted:
+    <value>某些数据无法删除：
 
 {0}
 
-Local backup saved to:
+本地备份已保存到：
 {1}
 
-You can restore from the Restore Saves panel.</value>
+您可以从"恢复存档"面板恢复。</value>
   </data>
   <data name="Apps_DeletedTitle" xml:space="preserve">
-    <value>Deleted</value>
+    <value>已删除</value>
   </data>
   <data name="Apps_DeletedMessage" xml:space="preserve">
-    <value>All save data for {0} ({1}) has been deleted.
+    <value>{0} ({1}) 的所有存档数据已删除。
 
-Backup saved to:
+备份已保存到：
 {2}
 
-You can restore from the Restore Saves panel.</value>
+您可以从"恢复存档"面板恢复。</value>
   </data>
   <data name="Apps_DeleteFailedTitle" xml:space="preserve">
-    <value>Delete Failed</value>
+    <value>删除失败</value>
   </data>
-
-  <!-- AppsPage orphan-blob scan + prune -->
   <data name="Apps_PruneTooltip" xml:space="preserve">
-    <value>Delete orphan cloud blobs no longer referenced by this app</value>
+    <value>删除此应用不再引用的孤立云数据块</value>
   </data>
   <data name="Apps_ScanForOrphans" xml:space="preserve">
-    <value>Scan Cloud for Orphans</value>
+    <value>扫描云端孤立文件</value>
   </data>
   <data name="Apps_ScanOrphansExplainTitle" xml:space="preserve">
-    <value>Scan Cloud for Orphans</value>
+    <value>扫描云端孤立文件</value>
   </data>
   <data name="Apps_ScanOrphansExplainMessage" xml:space="preserve">
-    <value>An "orphan" is a save file in your cloud storage that no app on this PC still references - left behind when a save was renamed, an app was uninstalled, or a sync was interrupted. They take up space and can shadow newer saves on conflict.
+    <value>"孤立文件"是指您云存储中的存档文件，这台 PC 上的任何应用都不再引用它 —— 在存档被重命名、应用被卸载或同步被中断时遗留下来的。它们占用空间，并可能在冲突时覆盖较新的存档。
 
-This scan only reads your cloud listings; nothing is deleted. After the scan, each affected app gets a "Review Orphans" button so you can inspect the files and decide whether to prune them.
+此扫描仅读取您的云列表；不会删除任何内容。扫描后，每个受影响的应用都会获得一个"查看孤立文件"按钮，以便您可以检查文件并决定是否清理它们。
 
-Steam must be closed during the scan so an in-flight upload can't be misread as an orphan. Continue?</value>
+扫描期间必须关闭 Steam，以便正在上传的文件不会被误读为孤立文件。</value>
   </data>
   <data name="Apps_ScanningOrphansFormat" xml:space="preserve">
-    <value>Scanning... ({0}/{1})</value>
+    <value>扫描中...（{0}/{1}）</value>
   </data>
   <data name="Apps_ScanLocalOnlyTitle" xml:space="preserve">
-    <value>No Cloud Provider</value>
+    <value>无云存储提供商</value>
   </data>
   <data name="Apps_ScanLocalOnlyMessage" xml:space="preserve">
-    <value>CloudRedirect is configured for local-only storage. There is no cloud to scan for orphan blobs.</value>
+    <value>CloudRedirect 配置为仅本地存储。没有云可以扫描孤立数据块。</value>
   </data>
   <data name="Apps_ScanFailedTitle" xml:space="preserve">
-    <value>Scan Failed</value>
+    <value>扫描失败</value>
   </data>
   <data name="Apps_ScanCompleteCleanFormat" xml:space="preserve">
-    <value>Scanned {0} app(s) - no orphan cloud blobs found.</value>
+    <value>已扫描 {0} 个应用 - 未找到孤立云数据块。</value>
   </data>
   <data name="Apps_ScanCompleteFoundFormat" xml:space="preserve">
-    <value>Found {0} orphan cloud blob(s) across {1} app(s).</value>
+    <value>在 {1} 个应用中找到 {0} 个孤立云数据块。</value>
   </data>
   <data name="Apps_ScanCompletePartialFormat" xml:space="preserve">
-    <value>{0} app(s) could not be verified (listing incomplete).</value>
+    <value>{0} 个应用无法验证（列表不完整）。</value>
   </data>
   <data name="Apps_OrphanSummaryFormat" xml:space="preserve">
-    <value>{0} unreferenced cloud blob(s)</value>
+    <value>{0} 个未引用的云数据块</value>
   </data>
   <data name="Apps_PruneAll" xml:space="preserve">
-    <value>Prune All</value>
+    <value>清理所有</value>
   </data>
   <data name="Apps_ReviewOrphans" xml:space="preserve">
-    <value>Review Orphans</value>
+    <value>查看孤立文件</value>
   </data>
   <data name="Apps_CollapseOrphans" xml:space="preserve">
-    <value>Collapse</value>
+    <value>折叠</value>
   </data>
   <data name="Apps_PruneScanningTitle" xml:space="preserve">
-    <value>Scanning cloud blobs...</value>
+    <value>扫描云数据块...</value>
   </data>
   <data name="Apps_PruneButton" xml:space="preserve">
-    <value>Prune</value>
+    <value>清理</value>
   </data>
   <data name="Apps_PruneButtonScanning" xml:space="preserve">
-    <value>Scanning...</value>
+    <value>扫描中...</value>
   </data>
   <data name="Apps_PruneButtonPruning" xml:space="preserve">
-    <value>Pruning...</value>
+    <value>清理中...</value>
   </data>
   <data name="Apps_PruneLocalOnlyTitle" xml:space="preserve">
-    <value>No Cloud Provider</value>
+    <value>无云存储提供商</value>
   </data>
   <data name="Apps_PruneLocalOnlyMessage" xml:space="preserve">
-    <value>CloudRedirect is configured for local-only storage. There is no cloud provider to prune orphan blobs from.</value>
+    <value>CloudRedirect 配置为仅本地存储。没有云存储提供商可以清理孤立数据块。</value>
   </data>
   <data name="Apps_PruneNoOrphansTitle" xml:space="preserve">
-    <value>No Orphan Blobs</value>
+    <value>无孤立数据块</value>
   </data>
   <data name="Apps_PruneNoOrphansMessageFormat" xml:space="preserve">
-    <value>All {0} cloud blob(s) for {1} are referenced by the local save index. Nothing to prune.</value>
+    <value>{1} 的所有 {0} 个云数据块都被本地存档索引引用。无需清理。</value>
   </data>
   <data name="Apps_PruneListingIncompleteTitle" xml:space="preserve">
-    <value>Cloud Listing Incomplete</value>
+    <value>云列表不完整</value>
   </data>
   <data name="Apps_PruneListingIncompleteMessage" xml:space="preserve">
-    <value>Could not retrieve a complete list of cloud blobs. Pruning on partial data would risk deleting legitimate saves, so the operation has been aborted. Try again when your connection to the cloud provider is stable.
+    <value>无法获取完整的云数据块列表。在部分数据上进行清理会有删除合法存档的风险，因此操作已中止。当您与云存储提供商的连接稳定时再试一次。
 
-Details: {0}</value>
+详细信息：{0}</value>
   </data>
   <data name="Apps_PruneConfirmTitle" xml:space="preserve">
-    <value>Prune Orphan Cloud Blobs</value>
+    <value>清理孤立云数据块</value>
   </data>
   <data name="Apps_PruneConfirmHeaderFormat" xml:space="preserve">
-    <value>Delete {0} orphan cloud blob(s) for {1} ({2})?
+    <value>删除 {1} ({2}) 的 {0} 个孤立云数据块？
 
 </value>
   </data>
   <data name="Apps_PruneConfirmExplanation" xml:space="preserve">
-    <value>These blobs exist in your cloud provider ({0}) but are NOT referenced by the local save index (file_tokens.dat). They were left behind by a prior session, a failed delete, or a manual override, and will never be downloaded or cleaned up by the normal sync path.
+    <value>这些数据块存在于您的云存储提供商 ({0}) 中，但未被本地存档索引 (file_tokens.dat) 引用。它们是由之前的会话、失败的删除或手动覆盖遗留下来的，永远不会被正常同步路径下载或清理。
 
 </value>
   </data>
   <data name="Apps_PruneConfirmPreviewHeader" xml:space="preserve">
-    <value>Files to delete:
+    <value>要删除的文件：
 </value>
   </data>
   <data name="Apps_PruneConfirmMoreFormat" xml:space="preserve">
-    <value>  ...and {0} more
+    <value>  ...还有 {0} 个
 </value>
   </data>
   <data name="Apps_PruneConfirmWarning" xml:space="preserve">
-    <value>This operation cannot be undone. Local saves will NOT be affected.</value>
+    <value>此操作无法撤消。本地存档不会受到影响。</value>
   </data>
   <data name="Apps_PruneFinalConfirmTitle" xml:space="preserve">
-    <value>Confirm Prune</value>
+    <value>确认清理</value>
   </data>
   <data name="Apps_PruneFinalConfirmMessageFormat" xml:space="preserve">
-    <value>Permanently delete {0} orphan cloud blob(s) for {1}? This cannot be undone.</value>
+    <value>永久删除 {1} 的 {0} 个孤立云数据块？此操作无法撤消。</value>
   </data>
   <data name="Apps_PruneCompleteTitle" xml:space="preserve">
-    <value>Prune Complete</value>
+    <value>清理完成</value>
   </data>
   <data name="Apps_PruneCompleteMessageFormat" xml:space="preserve">
-    <value>Deleted {0} orphan cloud blob(s) for {1}.</value>
+    <value>已删除 {1} 的 {0} 个孤立云数据块。</value>
   </data>
   <data name="Apps_PrunePartialTitle" xml:space="preserve">
-    <value>Prune Partially Complete</value>
+    <value>清理部分完成</value>
   </data>
   <data name="Apps_PrunePartialMessageFormat" xml:space="preserve">
-    <value>Deleted {0} of {1} orphan cloud blob(s) for {2}. {3} file(s) could not be deleted:
+    <value>已删除 {2} 的 {1} 个孤立云数据块中的 {0} 个。{3} 个文件无法删除：
 
 {4}
 
-Details: {5}</value>
+详细信息：{5}</value>
   </data>
   <data name="Apps_PruneFailedTitle" xml:space="preserve">
-    <value>Prune Failed</value>
+    <value>清理失败</value>
   </data>
   <data name="Apps_PruneFailedMessageFormat" xml:space="preserve">
-    <value>Could not delete any of the {0} orphan blob(s) for {1}.
+    <value>无法删除 {1} 的任何 {0} 个孤立数据块。
 
-Details: {2}</value>
+详细信息：{2}</value>
   </data>
-
   <data name="Apps_SteamNotFound" xml:space="preserve">
-    <value>Steam not found</value>
+    <value>未找到 Steam</value>
   </data>
   <data name="Apps_NoDeleteBackups" xml:space="preserve">
-    <value>No delete backups found.</value>
+    <value>未找到删除备份。</value>
   </data>
   <data name="Apps_BackupCountFormat" xml:space="preserve">
-    <value>{0} backup(s) found</value>
+    <value>找到 {0} 个备份</value>
   </data>
   <data name="Apps_FailedLoadBackups" xml:space="preserve">
-    <value>Failed to load backups: {0}</value>
+    <value>无法加载备份：{0}</value>
   </data>
   <data name="Apps_RestoreSavesExperimentalTitle" xml:space="preserve">
-    <value>Restore Saves (Experimental)</value>
+    <value>恢复存档（实验性）</value>
   </data>
   <data name="Apps_RestoreConfirmMessage" xml:space="preserve">
-    <value>Restore save data from backup at {0}?
+    <value>从 {0} 的备份恢复存档数据？
 
-Backup contains: {1} file(s) ({2})
-Apps: {3}
+备份包含：{1} 个文件（{2}）
+应用：{3}
 
-IMPORTANT: Before restoring, you must disable Steam Cloud for this game:
-  Steam > right-click the game > Properties > General >
-  uncheck "Keep game saves in the Steam Cloud"
+重要提示：在恢复之前，您必须为此游戏禁用 Steam 云：
+  Steam > 右键点击游戏 > 属性 > 常规 >
+  取消勾选"将游戏存档保存在 Steam 云中"
 
-If Steam Cloud is enabled, Steam may overwrite the restored files.
+如果启用了 Steam 云，Steam 可能会覆盖恢复的文件。
 
-This feature is experimental. Existing files at original locations will be skipped.
-The backup itself is never modified or deleted.</value>
+此功能是实验性的。原始位置上的现有文件将被跳过。
+备份本身永远不会被修改或删除。</value>
   </data>
   <data name="Apps_Restoring" xml:space="preserve">
-    <value>Restoring...</value>
+    <value>恢复中...</value>
   </data>
   <data name="Apps_Restore" xml:space="preserve">
-    <value>Restore</value>
+    <value>恢复</value>
   </data>
   <data name="Apps_RestoreCompleteTitle" xml:space="preserve">
-    <value>Restore Complete</value>
+    <value>恢复完成</value>
   </data>
   <data name="Apps_RestoredFormat" xml:space="preserve">
-    <value>Restored {0} file(s).</value>
+    <value>已恢复 {0} 个文件。</value>
   </data>
   <data name="Apps_RestoredRemotecacheFormat" xml:space="preserve">
-    <value> {0} remotecache(s).</value>
+    <value> {0} 个远程缓存。</value>
   </data>
   <data name="Apps_SkippedFormat" xml:space="preserve">
     <value>
-Skipped {0} file(s) (already exist at original location).</value>
+已跳过 {0} 个文件（原始位置已存在）。</value>
   </data>
   <data name="Apps_ErrorsFormat" xml:space="preserve">
     <value>
 
-{0} error(s):
+{0} 个错误：
 {1}</value>
   </data>
   <data name="Apps_RestoreFailedTitle" xml:space="preserve">
-    <value>Restore Failed</value>
+    <value>恢复失败</value>
   </data>
   <data name="Apps_AppFallbackName" xml:space="preserve">
-    <value>App {0}</value>
+    <value>应用 {0}</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- CleanupPage XAML                                                   -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Cleanup_Title" xml:space="preserve">
-    <value>Clean Up</value>
+    <value>清理</value>
   </data>
   <data name="Cleanup_Description" xml:space="preserve">
-    <value>SteamTools redirected the cloud saves of all Lua apps through app 760, polluting each Lua app's /&lt;appid&gt;/remote/ folder with all the files that SteamTools synced to 760. Scan to see which apps are affected, then select files to remove.</value>
+    <value>SteamTools 通过应用 760 重定向了所有 Lua 应用的云存档，将 SteamTools 同步到 760 的所有文件污染了每个 Lua 应用的 /&lt;appid&gt;/remote/ 文件夹。扫描以查看哪些应用受到影响，然后选择要删除的文件。</value>
   </data>
   <data name="Cleanup_OstBanner_Title" xml:space="preserve">
-    <value>OpenSteamTool detected</value>
+    <value>检测到 OpenSteamTool</value>
   </data>
   <data name="Cleanup_OstBanner_Description" xml:space="preserve">
-    <value>OpenSteamTool does not route cloud saves through app 760. This page is for cleaning up files left by a prior SteamTools install.</value>
+    <value>OpenSteamTool 不通过应用 760 路由云存档。此页面用于清理先前 SteamTools 安装遗留的文件。</value>
   </data>
   <data name="Cleanup_ScanForContamination" xml:space="preserve">
-    <value>Scan for Contamination</value>
+    <value>扫描污染</value>
   </data>
   <data name="Cleanup_RestoreFromBackup" xml:space="preserve">
-    <value>Restore from Backup</value>
+    <value>从备份恢复</value>
   </data>
   <data name="Cleanup_UndoBannerDescription" xml:space="preserve">
-    <value>The backup is safe - click Undo to restore all files to their original locations.</value>
+    <value>备份是安全的 - 点击"撤消"将所有文件恢复到其原始位置。</value>
   </data>
   <data name="Cleanup_Undo" xml:space="preserve">
-    <value>Undo</value>
+    <value>撤消</value>
   </data>
   <data name="Cleanup_Dismiss" xml:space="preserve">
-    <value>Dismiss</value>
+    <value>关闭</value>
   </data>
   <data name="Cleanup_ScanningApps" xml:space="preserve">
-    <value>Scanning apps...</value>
+    <value>扫描应用中...</value>
   </data>
   <data name="Cleanup_DangerZone" xml:space="preserve">
-    <value>Danger Zone</value>
+    <value>危险区域</value>
   </data>
   <data name="Cleanup_CleanAllSuspectFiles" xml:space="preserve">
-    <value>Clean All Suspect Files</value>
+    <value>清理所有可疑文件</value>
   </data>
   <data name="Cleanup_Back" xml:space="preserve">
-    <value>Back</value>
+    <value>返回</value>
   </data>
   <data name="Cleanup_RefreshBackups" xml:space="preserve">
-    <value>Refresh Backups</value>
+    <value>刷新备份</value>
   </data>
   <data name="Cleanup_RestoreDescription" xml:space="preserve">
-    <value>Restore files from a previous clean up backup. Each clean up run creates an immutable, timestamped backup. Restoring copies files back without modifying the backup.</value>
+    <value>从以前的清理备份中恢复文件。每次清理运行都会创建一个不可变的、带时间戳的备份。恢复会将文件复制回来而不修改备份。</value>
   </data>
   <data name="Cleanup_LoadingBackups" xml:space="preserve">
-    <value>Loading backups...</value>
+    <value>加载备份中...</value>
   </data>
-
-  <!-- CleanupPage code-behind -->
   <data name="Cleanup_SteamNotFound" xml:space="preserve">
-    <value>Steam not found</value>
+    <value>未找到 Steam</value>
   </data>
   <data name="Cleanup_NoNamespaceApps" xml:space="preserve">
-    <value>No namespace apps with files found.</value>
+    <value>未找到有文件的命名空间应用。</value>
   </data>
   <data name="Cleanup_ScanStatusFormat" xml:space="preserve">
-    <value>{0} apps scanned, {1} suspect files across {2} apps</value>
+    <value>已扫描 {0} 个应用，在 {2} 个应用中发现 {1} 个可疑文件</value>
   </data>
   <data name="Cleanup_NukeDescriptionFormat" xml:space="preserve">
-    <value>Remove all {0} suspect files ({1}) across {2} app(s) in one shot. Everything is backed up and can be restored from the Restore tab.</value>
+    <value>一次性删除 {2} 个应用中的所有 {0} 个可疑文件（{1}）。所有内容都会备份，可以从"恢复"选项卡恢复。</value>
   </data>
   <data name="Cleanup_ScanFailed" xml:space="preserve">
-    <value>Scan failed: {0}</value>
+    <value>扫描失败：{0}</value>
   </data>
   <data name="Cleanup_Cleaning" xml:space="preserve">
-    <value>Cleaning...</value>
+    <value>清理中...</value>
   </data>
   <data name="Cleanup_ConfirmCleanAllTitle" xml:space="preserve">
-    <value>Clean All Suspect Files</value>
+    <value>清理所有可疑文件</value>
   </data>
   <data name="Cleanup_ConfirmCleanAllMessage" xml:space="preserve">
-    <value>This will move {0} suspect file(s) ({1}) across {2} app(s) to the backup folder.
+    <value>这将把 {2} 个应用中的 {0} 个可疑文件（{1}）移动到备份文件夹。
 
-Backup location: cloud_redirect/cleanup_tab_backup/
+备份位置：cloud_redirect/cleanup_tab_backup/
 
-Everything can be restored from the Restore tab.
+所有内容都可以从"恢复"选项卡恢复。
 
-Are you sure?</value>
+您确定吗？</value>
   </data>
   <data name="Cleanup_CleanupCompleteTitle" xml:space="preserve">
-    <value>Clean Up Complete</value>
+    <value>清理完成</value>
   </data>
   <data name="Cleanup_CleanupCompleteMessage" xml:space="preserve">
-    <value>Moved {0} file(s) to backup.
-You can restore them from the Restore tab if needed.</value>
+    <value>已将 {0} 个文件移动到备份。
+如果需要，您可以从"恢复"选项卡恢复它们。</value>
   </data>
   <data name="Cleanup_CleanupFailedTitle" xml:space="preserve">
-    <value>Clean Up Failed</value>
+    <value>清理失败</value>
   </data>
   <data name="Cleanup_CleanedBannerFormat" xml:space="preserve">
-    <value>Cleaned {0} file(s) to backup.</value>
+    <value>已清理 {0} 个文件到备份。</value>
   </data>
   <data name="Cleanup_BackToScan" xml:space="preserve">
-    <value>Back to Scan</value>
+    <value>返回扫描</value>
   </data>
   <data name="Cleanup_NoBackupsFound" xml:space="preserve">
-    <value>No backups found.</value>
+    <value>未找到备份。</value>
   </data>
   <data name="Cleanup_BackupCountFormat" xml:space="preserve">
-    <value>{0} backup(s) found</value>
+    <value>找到 {0} 个备份</value>
   </data>
   <data name="Cleanup_FailedLoadBackups" xml:space="preserve">
-    <value>Failed to load backups: {0}</value>
+    <value>无法加载备份：{0}</value>
   </data>
   <data name="Cleanup_RestoreFromBackupTitle" xml:space="preserve">
-    <value>Restore from Backup</value>
+    <value>从备份恢复</value>
   </data>
   <data name="Cleanup_RestoreConfirmMessage" xml:space="preserve">
-    <value>This will copy files from the backup at {0} back to their original locations.
+    <value>这将把 {0} 的备份文件复制回其原始位置。
 
-Account: {1}
-Files: {2}
-Apps: {3}
+账户：{1}
+文件：{2}
+应用：{3}
 
-Existing files at original locations will be SKIPPED.
-The backup itself is never modified or deleted.
+原始位置上的现有文件将被跳过。
+备份本身永远不会被修改或删除。
 
-Continue?</value>
+继续？</value>
   </data>
   <data name="Cleanup_RestoreCompleteTitle" xml:space="preserve">
-    <value>Restore Complete</value>
+    <value>恢复完成</value>
   </data>
   <data name="Cleanup_RestoredFormat" xml:space="preserve">
-    <value>Restored {0} file(s), {1} remotecache(s).</value>
+    <value>已恢复 {0} 个文件，{1} 个远程缓存。</value>
   </data>
   <data name="Cleanup_SkippedFormat" xml:space="preserve">
     <value>
-Skipped {0} file(s) (already exist at original location).</value>
+已跳过 {0} 个文件（原始位置已存在）。</value>
   </data>
   <data name="Cleanup_ErrorsFormat" xml:space="preserve">
     <value>
 
-{0} error(s) occurred:
+发生 {0} 个错误：
 {1}</value>
   </data>
   <data name="Cleanup_RestoreFailedTitle" xml:space="preserve">
-    <value>Restore Failed</value>
+    <value>恢复失败</value>
   </data>
   <data name="Cleanup_UndoFailedTitle" xml:space="preserve">
-    <value>Undo Failed</value>
+    <value>撤消失败</value>
   </data>
   <data name="Cleanup_UndoSteamNotFound" xml:space="preserve">
-    <value>Steam not found.</value>
+    <value>未找到 Steam。</value>
   </data>
   <data name="Cleanup_UndoNoBackupFound" xml:space="preserve">
-    <value>Could not find the backup from the last clean up. Use Restore from Backup to find it manually.</value>
+    <value>无法找到上次清理的备份。使用"从备份恢复"手动查找。</value>
   </data>
   <data name="Cleanup_UndoCompleteTitle" xml:space="preserve">
-    <value>Undo Complete</value>
+    <value>撤消完成</value>
   </data>
-
-  <!-- Cleanup file classification badges -->
   <data name="Cleanup_Badge_CrossApp" xml:space="preserve">
-    <value>cross-app</value>
+    <value>跨应用</value>
   </data>
   <data name="Cleanup_Badge_WrongAppId" xml:space="preserve">
-    <value>wrong appid</value>
+    <value>错误的应用ID</value>
   </data>
   <data name="Cleanup_Badge_Mangled" xml:space="preserve">
-    <value>mangled</value>
+    <value>损坏</value>
   </data>
   <data name="Cleanup_Badge_Orphan" xml:space="preserve">
-    <value>orphan</value>
+    <value>孤立</value>
   </data>
   <data name="Cleanup_Badge_Legit" xml:space="preserve">
-    <value>legit</value>
+    <value>合法</value>
   </data>
   <data name="Cleanup_Badge_Unknown" xml:space="preserve">
-    <value>unknown</value>
+    <value>未知</value>
   </data>
-
-  <!-- Cleanup file list -->
   <data name="Cleanup_SuspectFiles" xml:space="preserve">
-    <value>Suspect Files</value>
+    <value>可疑文件</value>
   </data>
   <data name="Cleanup_Unknown" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="Cleanup_Legitimate" xml:space="preserve">
-    <value>Legitimate</value>
+    <value>合法</value>
   </data>
   <data name="Cleanup_GroupHeaderFormat" xml:space="preserve">
-    <value>{0} ({1})</value>
+    <value>{0}（{1}）</value>
   </data>
   <data name="Cleanup_Clean" xml:space="preserve">
-    <value>clean</value>
+    <value>干净</value>
   </data>
   <data name="Cleanup_Suspect" xml:space="preserve">
-    <value>{0} suspect</value>
+    <value>{0} 个可疑</value>
   </data>
   <data name="Cleanup_FilesCount" xml:space="preserve">
-    <value>{0} files</value>
+    <value>{0} 个文件</value>
   </data>
   <data name="Cleanup_ReviewFiles" xml:space="preserve">
-    <value>Review Files</value>
+    <value>查看文件</value>
   </data>
   <data name="Cleanup_ViewFiles" xml:space="preserve">
-    <value>View Files</value>
+    <value>查看文件</value>
   </data>
   <data name="Cleanup_Collapse" xml:space="preserve">
-    <value>Collapse</value>
+    <value>折叠</value>
   </data>
   <data name="Cleanup_SelectAllSuspect" xml:space="preserve">
-    <value>Select All Suspect</value>
+    <value>选择所有可疑</value>
   </data>
   <data name="Cleanup_DeselectAll" xml:space="preserve">
-    <value>Deselect All</value>
+    <value>取消全选</value>
   </data>
   <data name="Cleanup_CleanSelected" xml:space="preserve">
-    <value>Clean Selected</value>
+    <value>清理已选</value>
   </data>
   <data name="Cleanup_NothingSelectedTitle" xml:space="preserve">
-    <value>Nothing Selected</value>
+    <value>未选择任何内容</value>
   </data>
   <data name="Cleanup_NothingSelectedMessage" xml:space="preserve">
-    <value>Select files to remove by checking the boxes.</value>
+    <value>通过选中复选框来选择要删除的文件。</value>
   </data>
   <data name="Cleanup_ConfirmCleanupTitle" xml:space="preserve">
-    <value>Confirm Clean Up</value>
+    <value>确认清理</value>
   </data>
   <data name="Cleanup_ConfirmCleanupMessage" xml:space="preserve">
-    <value>This will move {0} file(s) ({1}) to the backup folder.
+    <value>这将把 {0} 个文件（{1}）移动到备份文件夹。
 
-Backup location: cloud_redirect/cleanup_tab_backup/{2}/
+备份位置：cloud_redirect/cleanup_tab_backup/{2}/
 
-Files can be restored from the Restore tab. Continue?</value>
+可以从"恢复"选项卡恢复文件。继续？</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- SettingsPage XAML                                                  -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Settings_Title" xml:space="preserve">
-    <value>Settings</value>
+    <value>设置</value>
   </data>
   <data name="Settings_Updates" xml:space="preserve">
-    <value>Updates</value>
+    <value>更新</value>
   </data>
   <data name="Settings_CheckForUpdates" xml:space="preserve">
-    <value>Check for Updates</value>
+    <value>检查更新</value>
   </data>
   <data name="Settings_CheckForUpdatesHint" xml:space="preserve">
-    <value>Click to check for a newer version.</value>
+    <value>点击检查较新版本。</value>
   </data>
   <data name="Settings_Check" xml:space="preserve">
-    <value>Check</value>
+    <value>检查</value>
   </data>
   <data name="Settings_Download" xml:space="preserve">
-    <value>Download</value>
+    <value>下载</value>
   </data>
   <data name="Settings_DangerZone" xml:space="preserve">
-    <value>Danger Zone</value>
+    <value>危险区域</value>
   </data>
   <data name="Settings_ResetCacheTitle" xml:space="preserve">
-    <value>Reset Local CloudRedirect Cache</value>
+    <value>重置本地 CloudRedirect 缓存</value>
   </data>
   <data name="Settings_ResetCacheDescription" xml:space="preserve">
-    <value>Deletes CloudRedirect local cache. This only removes the cache and forces the cloud provider to resync.</value>
+    <value>删除 CloudRedirect 本地缓存。这仅删除缓存并强制云提供商重新同步。</value>
   </data>
   <data name="Settings_Reset" xml:space="preserve">
-    <value>Reset</value>
+    <value>重置</value>
   </data>
   <data name="Settings_SwitchMode" xml:space="preserve">
-    <value>Switch Mode</value>
+    <value>切换模式</value>
   </data>
   <data name="Settings_SwitchModeTitle" xml:space="preserve">
-    <value>App Mode</value>
+    <value>应用模式</value>
   </data>
   <data name="Settings_SwitchModeHint" xml:space="preserve">
-    <value>Choose between ST Fixer (core fixes only) and Cloud Redirect (adds cloud save redirection).</value>
+    <value>在 ST Fixer（仅核心修复）和 Cloud Redirect（添加云存档重定向）之间选择。</value>
   </data>
   <data name="Settings_ModeStFixer" xml:space="preserve">
     <value>ST Fixer</value>
@@ -1416,265 +1417,87 @@ Files can be restored from the Restore tab. Continue?</value>
     <value>Cloud Redirect</value>
   </data>
   <data name="Settings_ModeThirdParty" xml:space="preserve">
-    <value>Third-Party Client</value>
+    <value>第三方客户端</value>
   </data>
   <data name="Settings_About" xml:space="preserve">
-    <value>About</value>
+    <value>关于</value>
   </data>
   <data name="Settings_CloudRedirect" xml:space="preserve">
     <value>CloudRedirect</value>
   </data>
   <data name="Settings_AboutDescription" xml:space="preserve">
-    <value>Cloud saves for non-owned Steam games</value>
+    <value>非自有 Steam 游戏的云存档</value>
   </data>
   <data name="Settings_GitHub" xml:space="preserve">
     <value>GitHub</value>
   </data>
-
-  <!-- SettingsPage code-behind -->
   <data name="Settings_VersionFormat" xml:space="preserve">
     <value>{0}.{1}.{2}</value>
   </data>
   <data name="Settings_Checking" xml:space="preserve">
-    <value>Checking...</value>
+    <value>检查中...</value>
   </data>
   <data name="Settings_ContactingGitHub" xml:space="preserve">
-    <value>Contacting GitHub...</value>
+    <value>正在联系 GitHub...</value>
   </data>
   <data name="Settings_UpdateAvailableFormat" xml:space="preserve">
-    <value>Update Available: {0}</value>
+    <value>可用更新：{0}</value>
   </data>
   <data name="Settings_NewerVersionAvailable" xml:space="preserve">
-    <value>A newer version is available. You are running v{0}.</value>
+    <value>有较新版本可用。您正在运行 v{0}。</value>
   </data>
   <data name="Settings_UpToDate" xml:space="preserve">
-    <value>Up to Date</value>
+    <value>已是最新</value>
   </data>
   <data name="Settings_LatestVersionFormat" xml:space="preserve">
-    <value>You are running the latest version (v{0}).</value>
+    <value>您正在运行最新版本（v{0}）。</value>
   </data>
   <data name="Settings_LatestReleaseFormat" xml:space="preserve">
-    <value>Latest Release: {0}</value>
+    <value>最新版本：{0}</value>
   </data>
   <data name="Settings_CouldNotCompare" xml:space="preserve">
-    <value>Could not compare versions automatically.</value>
+    <value>无法自动比较版本。</value>
   </data>
   <data name="Settings_FailedToCheck" xml:space="preserve">
-    <value>Failed to check: {0}</value>
+    <value>检查失败：{0}</value>
   </data>
   <data name="Settings_ConfirmResetTitle" xml:space="preserve">
-    <value>Confirm Reset</value>
+    <value>确认重置</value>
   </data>
   <data name="Settings_ConfirmResetMessage" xml:space="preserve">
-    <value>This will delete the CloudRedirect local cache and force the cloud provider to resync.
+    <value>这将删除 CloudRedirect 本地缓存并强制云提供商重新同步。
 
-Are you sure?</value>
+您确定吗？</value>
   </data>
   <data name="Settings_Done" xml:space="preserve">
-    <value>Done</value>
+    <value>完成</value>
   </data>
   <data name="Settings_ResetDoneMessage" xml:space="preserve">
-    <value>Local cache has been reset. The cloud provider will resync on next launch.</value>
+    <value>本地缓存已重置。云提供商将在下次启动时重新同步。</value>
   </data>
   <data name="Settings_FailedReset" xml:space="preserve">
-    <value>Failed to reset: {0}</value>
+    <value>重置失败：{0}</value>
   </data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!-- DisclaimerWindow XAML                                              -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <data name="Disclaimer_WindowTitle" xml:space="preserve">
-    <value>Change Mode?</value>
-  </data>
-  <data name="Disclaimer_Heading" xml:space="preserve">
-    <value>Life is about choices.</value>
-  </data>
-  <data name="Disclaimer_Intro" xml:space="preserve">
-    <value>There used to be a scary screen here. That screen is gone now. Life is about choices. I mean, life is really about other people but that's a bit heavy for a warning screen. A former warning screen, even.</value>
-  </data>
-  <data name="Disclaimer_HowItWorks" xml:space="preserve">
-    <value>Cloud Redirect does very silly things that results in Steam Cloud operations being redirected towards a provider of your choice. If that provider is Google Drive specifically, you have access to Google Drive file versioning. You can pull down older versions of saves.</value>
-  </data>
-  <data name="Disclaimer_TrackRecord" xml:space="preserve">
-    <value>In practice, this makes Cloud Redirect mode very low risk. I've had maybe...three? reported incidents of data loss in a release build ever. Two were in extremely early versions and I was able to recover the data for the users. One was more recent, caused by a component that does not exist anymore and a network failure at the worst possible time &amp; was not reported to me until days later, resulted in an hour of lost progress. I would have been able to recover the data, but the user progressed past that point before I was sent logs.</value>
-  </data>
-  <data name="Disclaimer_ChoiceHeading" xml:space="preserve">
-    <value>Time to make a choice.</value>
-  </data>
-  <data name="Disclaimer_ChoiceIntegrity" xml:space="preserve">
-    <value>If you are worried about the integrity of your on disk saves most of all, this may not be the tool for you. It's been fine for me and for many others, but it may not suit you.</value>
-  </data>
-  <data name="Disclaimer_ChoiceBackup" xml:space="preserve">
-    <value>If your failure scenario is 'reinstalling Windows and forgetting to backup all my saves/hardware failure/game crashes and corrupts save', CR can help.</value>
-  </data>
-  <data name="Disclaimer_ChoiceMultiPC" xml:space="preserve">
-    <value>If you want to play a game across two (or more) different PCs, CR is the best way to do that. It's more reliable than anything else.</value>
-  </data>
-  <data name="Disclaimer_Closing" xml:space="preserve">
-    <value>Make your choice. No judgement.</value>
-  </data>
-  <data name="Disclaimer_Cancel" xml:space="preserve">
-    <value>Not for me</value>
-  </data>
-  <data name="Disclaimer_AcceptButton" xml:space="preserve">
-    <value>Enable Cloud Redirect Mode?</value>
-  </data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!-- Dialog.cs                                                          -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <data name="Dialog_OK" xml:space="preserve">
-    <value>OK</value>
-  </data>
-  <data name="Dialog_Yes" xml:space="preserve">
-    <value>Yes</value>
-  </data>
-  <data name="Dialog_No" xml:space="preserve">
-    <value>No</value>
-  </data>
-  <data name="Dialog_YesCountdownFormat" xml:space="preserve">
-    <value>Yes ({0})</value>
-  </data>
-  <data name="Dialog_YesDeleteEverything" xml:space="preserve">
-    <value>Yes - DELETE EVERYTHING</value>
-  </data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!-- SteamDetector.cs                                                   -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <data name="Steam_IsRunningTitle" xml:space="preserve">
-    <value>Steam Is Running</value>
-  </data>
-  <data name="Steam_IsRunningMessage" xml:space="preserve">
-    <value>Steam must be closed before continuing. Please close Steam and try again.</value>
-  </data>
-
-  <!-- CloudConfig.DisplayName -->
-  <data name="Provider_GoogleDrive" xml:space="preserve">
-    <value>Google Drive</value>
-  </data>
-  <data name="Provider_OneDrive" xml:space="preserve">
-    <value>OneDrive</value>
-  </data>
-  <data name="Provider_FolderNetworkDrive" xml:space="preserve">
-    <value>Folder / Network Drive</value>
-  </data>
-  <data name="Provider_LocalOnly" xml:space="preserve">
-    <value>Local only</value>
-  </data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!-- BackupListBuilder.cs                                               -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <data name="Backup_UnknownApp" xml:space="preserve">
-    <value>Unknown App</value>
-  </data>
-  <data name="Backup_AppIdFormat" xml:space="preserve">
-    <value>AppID {0}</value>
-  </data>
-  <data name="Backup_Legacy" xml:space="preserve">
-    <value>legacy</value>
-  </data>
-  <data name="Backup_Recent" xml:space="preserve">
-    <value>recent</value>
-  </data>
-  <data name="Backup_FileCountFormat" xml:space="preserve">
-    <value>{0} file(s)</value>
-  </data>
-  <data name="Backup_OperationsFormat" xml:space="preserve">
-    <value>{0} op(s)</value>
-  </data>
-  <data name="Backup_OtherAppsFormat" xml:space="preserve">
-    <value>(+ {0} other app{1})</value>
-  </data>
-  <data name="Backup_Preview" xml:space="preserve">
-    <value>Preview</value>
-  </data>
-  <data name="Backup_HidePreview" xml:space="preserve">
-    <value>Hide Preview</value>
-  </data>
-  <data name="Backup_Loading" xml:space="preserve">
-    <value>Loading...</value>
-  </data>
-  <data name="Backup_NoFilesOnDisk" xml:space="preserve">
-    <value>No backup files found on disk</value>
-  </data>
-
-  <!-- Shared preview/restore text -->
-  <data name="Preview_SummaryFormat" xml:space="preserve">
-    <value>Preview: {0} file(s) would be restored, {1} skipped (already exist), {2} remotecache(s)</value>
-  </data>
-  <data name="Preview_Failed" xml:space="preserve">
-    <value>Preview failed</value>
-  </data>
-  <data name="Preview_ErrorsHeader" xml:space="preserve">
-    <value>Errors:
-{0}</value>
-  </data>
-  <data name="Preview_FailedTitle" xml:space="preserve">
-    <value>Preview Failed</value>
-  </data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!-- EmbeddedDll.cs                                                     -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <data name="EmbeddedDll_NotEmbedded" xml:space="preserve">
-    <value>cloud_redirect.dll is not embedded in this build</value>
-  </data>
-  <data name="EmbeddedDll_InUse" xml:space="preserve">
-    <value>cloud_redirect.dll is in use (close Steam first)</value>
-  </data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!-- Common / Shared                                                    -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <data name="Common_Info" xml:space="preserve">
-    <value>Info</value>
-  </data>
-  <data name="Common_Error" xml:space="preserve">
-    <value>Error</value>
-  </data>
-  <data name="Common_UpdateFailed" xml:space="preserve">
-    <value>Update Failed</value>
-  </data>
-
-  <!-- OAuthService browser pages (user-facing HTML) -->
-  <data name="OAuth_AuthSuccessTitle" xml:space="preserve">
-    <value>Authorization Successful</value>
-  </data>
-  <data name="OAuth_AuthSuccessBody" xml:space="preserve">
-    <value>You can close this tab and return to CloudRedirect.</value>
-  </data>
-  <data name="OAuth_AuthFailedTitle" xml:space="preserve">
-    <value>Authorization Failed</value>
-  </data>
-  <data name="OAuth_AuthFailedBody" xml:space="preserve">
-    <value>Please close this tab and try again.</value>
-  </data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!-- Language Selector (SettingsPage)                                   -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Settings_Language" xml:space="preserve">
-    <value>Language</value>
+    <value>语言</value>
   </data>
   <data name="Settings_LanguageHint" xml:space="preserve">
-    <value>Select your preferred language. Changes take effect after restart.</value>
+    <value>选择您的首选语言。更改将在重启后生效。</value>
   </data>
   <data name="Settings_RestartRequired" xml:space="preserve">
-    <value>Restart required to change language.</value>
+    <value>需要重启才能更改语言。</value>
   </data>
   <data name="Settings_RestartNow" xml:space="preserve">
-    <value>Restart Now</value>
+    <value>立即重启</value>
   </data>
   <data name="Settings_FailedSaveLanguage" xml:space="preserve">
-    <value>Couldn't save language preference: {0}</value>
+    <value>无法保存语言偏好：{0}</value>
   </data>
   <data name="Settings_FailedSaveSync" xml:space="preserve">
-    <value>Couldn't save sync settings: {0}</value>
+    <value>无法保存同步设置：{0}</value>
   </data>
   <data name="Settings_SystemDefault" xml:space="preserve">
-    <value>System Default</value>
+    <value>系统默认</value>
   </data>
   <data name="Settings_LanguageEnglish" xml:space="preserve">
     <value>English</value>
@@ -1689,338 +1512,485 @@ Are you sure?</value>
     <value>简体中文</value>
   </data>
   <data name="Settings_Sync" xml:space="preserve">
-    <value>Sync</value>
+    <value>同步</value>
   </data>
   <data name="Settings_SyncHint" xml:space="preserve">
-    <value>These settings control what data is synced between your PCs via the cloud provider. Changes take effect after restarting Steam.</value>
+    <value>这些设置控制通过云提供商在您的 PC 之间同步哪些数据。更改将在重启 Steam 后生效。</value>
   </data>
   <data name="Settings_SyncAchievements" xml:space="preserve">
-    <value>Sync Achievements</value>
+    <value>同步成就</value>
   </data>
   <data name="Settings_SyncAchievementsHint" xml:space="preserve">
-    <value>Upload and merge achievement progress for lua apps across PCs.</value>
+    <value>上传并合并 Lua 应用在各 PC 之间的成就进度。</value>
   </data>
   <data name="Settings_SyncPlaytime" xml:space="preserve">
-    <value>Sync Playtime</value>
+    <value>同步游戏时长</value>
   </data>
   <data name="Settings_SyncPlaytimeHint" xml:space="preserve">
-    <value>Upload and merge playtime data for lua apps across PCs.</value>
-  </data>
-  <data name="CloudProvider_UploadInFlight" xml:space="preserve">
-    <value>Concurrent Upload Size</value>
-  </data>
-  <data name="CloudProvider_UploadInFlightHint" xml:space="preserve">
-    <value>Controls the maximum file size of concurrent uploads. Increasing WILL NOT speed up loads, but increasing it can make multiple large saves fail to upload. Changes are not recommended. Only change if you know what you are doing.</value>
-  </data>
-  <data name="CloudProvider_UploadInFlightValue" xml:space="preserve">
-    <value>{0} MB</value>
-  </data>
-  <data name="CloudProvider_UploadInFlightConservative" xml:space="preserve">
-    <value>Safe (24)</value>
-  </data>
-  <data name="CloudProvider_UploadInFlightBalanced" xml:space="preserve">
-    <value>Balanced (44)</value>
-  </data>
-  <data name="CloudProvider_UploadInFlightAggressive" xml:space="preserve">
-    <value>Aggressive (64)</value>
+    <value>上传并合并 Lua 应用在各 PC 之间的游戏时长数据。</value>
   </data>
   <data name="Settings_SyncLuas" xml:space="preserve">
-    <value>Sync Lua Files</value>
+    <value>同步 Lua 文件</value>
   </data>
   <data name="Settings_SyncLuasHint" xml:space="preserve">
-    <value>Sync lua files themselves between PCs so you don't have to install them again.</value>
+    <value>在 PC 之间同步 Lua 文件本身，这样您就不必再次安装它们。</value>
   </data>
   <data name="Settings_AutoUpdateDll" xml:space="preserve">
-    <value>Auto-Update DLL</value>
+    <value>自动更新 DLL</value>
   </data>
   <data name="Settings_AutoUpdateDllHint" xml:space="preserve">
-    <value>Automatically check for and install newer versions of the CloudRedirect DLL when Steam launches. The update takes effect on the next Steam restart.</value>
+    <value>Steam 启动时自动检查并安装较新版本的 CloudRedirect DLL。更新将在下次 Steam 重启时生效。</value>
   </data>
   <data name="Settings_Extra" xml:space="preserve">
-    <value>Quality of Life</value>
+    <value>体验优化</value>
   </data>
   <data name="Settings_ExtraHint" xml:space="preserve">
-    <value>Optional extras that aren't part of cloud sync.</value>
+    <value>不属于云同步的可选额外功能。</value>
   </data>
   <data name="Settings_ShowNonSteamGame" xml:space="preserve">
-    <value>Show Lua Game in Status</value>
+    <value>在状态中显示 Lua 游戏</value>
   </data>
   <data name="Settings_ShowNonSteamGameHint" xml:space="preserve">
-    <value>When playing a game unlocked by a Lua, show it as your Steam status instead of appearing online but not actively in a game.</value>
+    <value>玩由 Lua 解锁的游戏时，将其显示为您的 Steam 状态，而不是显示在线但未在游戏中。</value>
   </data>
   <data name="Settings_Experimental" xml:space="preserve">
-    <value>Experimental Features</value>
+    <value>实验性功能</value>
   </data>
   <data name="Settings_ExperimentalHint" xml:space="preserve">
-    <value>PLACEHOLDER LOREM IPSUM</value>
+    <value>占位符文本</value>
   </data>
   <data name="Settings_GetAchievementData" xml:space="preserve">
-    <value>Make Achievements Work</value>
+    <value>修复成就</value>
   </data>
   <data name="Settings_GetAchievementDataHint" xml:space="preserve">
-    <value>Grab achievement data from Steam, makes achievements appear for games that ST itself does not get achievement data for.</value>
+    <value>从 Steam 获取成就数据，使 ST 本身不获取成就数据的游戏的成就显示出来。</value>
   </data>
-
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!-- Cloud Redirect Toggle                                               -->
-  <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Settings_CloudRedirectEnabled" xml:space="preserve">
-    <value>Enable Cloud Save Redirection</value>
+    <value>启用云存档重定向</value>
   </data>
   <data name="Settings_CloudRedirectEnabledHint" xml:space="preserve">
-    <value>When enabled, cloud saves for lua apps are intercepted and stored locally (and optionally synced to your cloud provider). When disabled, only manifest pinning and patches are active. Changes take effect after restarting Steam.</value>
+    <value>启用时，Lua 应用的云存档将被拦截并存储在本地（并可选择同步到您的云提供商）。禁用时，仅激活清单固定和补丁。更改将在重启 Steam 后生效。</value>
+  </data>
+  <data name="Settings_ManifestPinning" xml:space="preserve">
+    <value>清单固定</value>
+  </data>
+  <data name="Settings_ManifestPinningHint" xml:space="preserve">
+    <value>控制 Lua 应用是否可以固定到特定版本。可以在 Steam 文件夹的配置文件中配置每个应用的固定。更改将在重启 Steam 后生效。</value>
+  </data>
+  <data name="Settings_ManifestPinningEnabled" xml:space="preserve">
+    <value>启用清单固定</value>
+  </data>
+  <data name="Settings_ManifestPinningEnabledHint" xml:space="preserve">
+    <value>启用时，Lua 应用可以锁定到特定版本。</value>
+  </data>
+  <data name="Settings_AutoComment" xml:space="preserve">
+    <value>自动注释 SetManifestID</value>
+  </data>
+  <data name="Settings_AutoCommentHint" xml:space="preserve">
+    <value>启用时，Lua 中指定的 SetManifestID 将被视为注释掉的。如果禁用，将遵守 SetManifestID，这意味着您的游戏将锁定到 Lua 中指定的版本。此设置永远不会修改磁盘上的 Lua 文件。</value>
+  </data>
+  <data name="Settings_Parental" xml:space="preserve">
+    <value>Steam 家庭</value>
+  </data>
+  <data name="Settings_ParentalHint" xml:space="preserve">
+    <value>禁用 Steam 家庭 限制</value>
+  </data>
+  <data name="Settings_ParentalIgnorePlaytime" xml:space="preserve">
+    <value>忽略游戏时长限制</value>
+  </data>
+  <data name="Settings_ParentalIgnorePlaytimeHint" xml:space="preserve">
+    <value>解除游戏时长上限限制，时长统计将记录至设定阈值且不会超出该数值。</value>
+  </data>
+  <data name="Settings_ParentalBypassPlaytime" xml:space="preserve">
+    <value>禁用家庭限制</value>
+  </data>
+  <data name="Settings_ParentalBypassPlaytimeHint" xml:space="preserve">
+    <value>不再强制生效客户端家庭管控限制</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <!-- Manifest Pinning                                                    -->
+  <!-- DisclaimerWindow XAML                                              -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
-  <data name="Settings_ManifestPinning" xml:space="preserve">
-    <value>Manifest Pinning</value>
+  <data name="Disclaimer_WindowTitle" xml:space="preserve">
+    <value>更改模式？</value>
   </data>
-  <data name="Settings_ManifestPinningHint" xml:space="preserve">
-    <value>Control whether lua apps can be pinned to specific versions. Per-app pins can be configured in the config file at the Steam folder. Changes take effect after restarting Steam.</value>
+  <data name="Disclaimer_Heading" xml:space="preserve">
+    <value>生活就是选择。</value>
   </data>
-  <data name="Settings_ManifestPinningEnabled" xml:space="preserve">
-    <value>Enable Manifest Pinning</value>
+  <data name="Disclaimer_Intro" xml:space="preserve">
+    <value>此处曾设有警示弹窗，现已移除。人生处处皆是抉择，说到底生活本就与人息息相关，只是放在警示提示上未免太过厚重，即便对旧版弹窗而言亦是如此。</value>
   </data>
-  <data name="Settings_ManifestPinningEnabledHint" xml:space="preserve">
-    <value>When enabled, lua apps can be locked to specific versions.</value>
+  <data name="Disclaimer_HowItWorks" xml:space="preserve">
+    <value>Cloud Redirect 采用特殊重定向机制，将Steam云存储操作转至用户指定存储服务商。若选择Google Drive，可借助其文件版本回溯功能，调取存档历史旧版本。</value>
   </data>
-  <data name="Settings_AutoComment" xml:space="preserve">
-    <value>Auto Comment SetManifestID</value>
+  <data name="Disclaimer_TrackRecord" xml:space="preserve">
+    <value>实际上Cloud Redirect模式的风险极低。正式版本里仅收到过三起数据丢失反馈：两起出现在早期版本，当时我已协助用户完整恢复数据；还有一起近期案例，因已废弃组件叠加突发网络故障引发，用户时隔数日才反馈，最终丢失一小时游戏进度。虽原本可挽回存档，但用户发送日志时数据覆盖已久，无法复原。</value>
   </data>
-  <data name="Settings_AutoCommentHint" xml:space="preserve">
-    <value>When enabled, the SetManifestID specified in the lua will be treated as if it were commented out. If disabled, the SetManifestID will be respected, meaning your game will be locked to the version specified in the lua. This setting never modifies lua files on disk.</value>
+  <data name="Disclaimer_ChoiceHeading" xml:space="preserve">
+    <value>是时候做出选择了。</value>
+  </data>
+  <data name="Disclaimer_ChoiceIntegrity" xml:space="preserve">
+    <value>若您极度看重本地存档文件的完整可靠性，本工具或许并不适配。该工具虽能稳定满足我与多数用户的使用需求，但未必契合您的使用诉求。</value>
+  </data>
+  <data name="Disclaimer_ChoiceBackup" xml:space="preserve">
+    <value>若你遇到重装系统未备份存档、硬件故障、游戏闪退损坏存档等情况，CR均可提供存档恢复支持。</value>
+  </data>
+  <data name="Disclaimer_ChoiceMultiPC" xml:space="preserve">
+    <value>如需在两台及多台设备间游玩游戏，CR是最优解决方案，稳定性优于各类替代方案。</value>
+  </data>
+  <data name="Disclaimer_Closing" xml:space="preserve">
+    <value>做出您的选择。不做评判。</value>
+  </data>
+  <data name="Disclaimer_Cancel" xml:space="preserve">
+    <value>不适合我</value>
+  </data>
+  <data name="Disclaimer_AcceptButton" xml:space="preserve">
+    <value>启用 Cloud Redirect 模式？</value>
+  </data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- Dialog.cs                                                          -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <data name="Dialog_OK" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="Dialog_Yes" xml:space="preserve">
+    <value>是</value>
+  </data>
+  <data name="Dialog_No" xml:space="preserve">
+    <value>否</value>
+  </data>
+  <data name="Dialog_YesCountdownFormat" xml:space="preserve">
+    <value>是（{0}）</value>
+  </data>
+  <data name="Dialog_YesDeleteEverything" xml:space="preserve">
+    <value>是 - 删除所有内容</value>
+  </data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- SteamDetector.cs                                                   -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <data name="Steam_IsRunningTitle" xml:space="preserve">
+    <value>Steam 正在运行</value>
+  </data>
+  <data name="Steam_IsRunningMessage" xml:space="preserve">
+    <value>继续之前必须关闭 Steam。请关闭 Steam 并重试。</value>
+  </data>
+
+  <!-- CloudConfig.DisplayName -->
+  <data name="Provider_GoogleDrive" xml:space="preserve">
+    <value>Google Drive</value>
+  </data>
+  <data name="Provider_OneDrive" xml:space="preserve">
+    <value>OneDrive</value>
+  </data>
+  <data name="Provider_FolderNetworkDrive" xml:space="preserve">
+    <value>文件夹 / 映射驱动器</value>
+  </data>
+  <data name="Provider_LocalOnly" xml:space="preserve">
+    <value>仅本地</value>
+  </data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- BackupListBuilder.cs                                               -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <data name="Backup_UnknownApp" xml:space="preserve">
+    <value>未知应用</value>
+  </data>
+  <data name="Backup_AppIdFormat" xml:space="preserve">
+    <value>应用ID {0}</value>
+  </data>
+  <data name="Backup_Legacy" xml:space="preserve">
+    <value>旧版</value>
+  </data>
+  <data name="Backup_Recent" xml:space="preserve">
+    <value>最近</value>
+  </data>
+  <data name="Backup_FileCountFormat" xml:space="preserve">
+    <value>{0} 个文件</value>
+  </data>
+  <data name="Backup_OperationsFormat" xml:space="preserve">
+    <value>{0} 项操作</value>
+  </data>
+  <data name="Backup_OtherAppsFormat" xml:space="preserve">
+    <value>（+ {0} 个其他应用{1}）</value>
+  </data>
+  <data name="Backup_Preview" xml:space="preserve">
+    <value>预览</value>
+  </data>
+  <data name="Backup_HidePreview" xml:space="preserve">
+    <value>隐藏预览</value>
+  </data>
+  <data name="Backup_Loading" xml:space="preserve">
+    <value>加载中...</value>
+  </data>
+  <data name="Backup_NoFilesOnDisk" xml:space="preserve">
+    <value>磁盘上未找到备份文件</value>
+  </data>
+
+  <!-- Shared preview/restore text -->
+  <data name="Preview_SummaryFormat" xml:space="preserve">
+    <value>预览：将恢复 {0} 个文件，跳过 {1} 个（已存在），{2} 个远程缓存</value>
+  </data>
+  <data name="Preview_Failed" xml:space="preserve">
+    <value>预览失败</value>
+  </data>
+  <data name="Preview_ErrorsHeader" xml:space="preserve">
+    <value>错误：
+{0}</value>
+  </data>
+  <data name="Preview_FailedTitle" xml:space="preserve">
+    <value>预览失败</value>
+  </data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- EmbeddedDll.cs                                                     -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <data name="EmbeddedDll_NotEmbedded" xml:space="preserve">
+    <value>cloud_redirect.dll 未嵌入此构建</value>
+  </data>
+  <data name="EmbeddedDll_InUse" xml:space="preserve">
+    <value>cloud_redirect.dll 正在使用中（请先关闭 Steam）</value>
+  </data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <!-- Common / Shared                                                    -->
+  <!-- ═══════════════════════════════════════════════════════════════════ -->
+  <data name="Common_Info" xml:space="preserve">
+    <value>信息</value>
+  </data>
+  <data name="Common_Error" xml:space="preserve">
+    <value>错误</value>
+  </data>
+  <data name="Common_UpdateFailed" xml:space="preserve">
+    <value>更新失败</value>
+  </data>
+
+  <!-- OAuthService browser pages (user-facing HTML) -->
+  <data name="OAuth_AuthSuccessTitle" xml:space="preserve">
+    <value>授权成功</value>
+  </data>
+  <data name="OAuth_AuthSuccessBody" xml:space="preserve">
+    <value>您可以关闭此选项卡并返回 CloudRedirect。</value>
+  </data>
+  <data name="OAuth_AuthFailedTitle" xml:space="preserve">
+    <value>授权失败</value>
+  </data>
+  <data name="OAuth_AuthFailedBody" xml:space="preserve">
+    <value>请关闭此选项卡并重试。</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- Per-app Manifest Pins                                               -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Pin_PerAppTitle" xml:space="preserve">
-    <value>Lua apps</value>
+    <value>Lua 应用</value>
   </data>
   <data name="Pin_PerAppHint" xml:space="preserve">
-    <value>These are your lua games/apps. Enable the app below to pin it to the version specified in the lua. When auto comment is on, only apps enabled here will be pinned. Changes take effect after restarting Steam.</value>
+    <value>这些是您的 Lua 游戏/应用。启用下面的应用以将其固定到 Lua 中指定的版本。当自动注释开启时，只有在此处启用的应用才会被固定。更改将在重启 Steam 后生效。</value>
   </data>
   <data name="Pin_AppId" xml:space="preserve">
-    <value>App ID</value>
+    <value>应用ID</value>
   </data>
   <data name="Pin_DepotId" xml:space="preserve">
-    <value>Depot ID</value>
+    <value>仓库ID</value>
   </data>
   <data name="Pin_ManifestId" xml:space="preserve">
-    <value>Manifest ID</value>
+    <value>清单ID</value>
   </data>
   <data name="Pin_Add" xml:space="preserve">
-    <value>Add</value>
+    <value>添加</value>
   </data>
   <data name="Pin_Remove" xml:space="preserve">
-    <value>Remove</value>
+    <value>删除</value>
   </data>
   <data name="Pin_NoEntries" xml:space="preserve">
-    <value>No lua files with setManifestid found.</value>
+    <value>未找到带有 setManifestid 的 Lua 文件。</value>
   </data>
   <data name="Pin_AppFallbackName" xml:space="preserve">
-    <value>App {0}</value>
+    <value>应用 {0}</value>
   </data>
   <data name="Pin_FailedSavePinConfig" xml:space="preserve">
-    <value>Couldn't save pin configuration: {0}</value>
+    <value>无法保存固定配置：{0}</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- Search                                                              -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Search_Placeholder" xml:space="preserve">
-    <value>Search by name or app ID...</value>
+    <value>按名称或应用ID搜索...</value>
   </data>
 
-  <!-- ═══════════════════════ Parental Controls ═════════════════════════ -->
-  <data name="Settings_Parental" xml:space="preserve">
-    <value>Steam Family</value>
-  </data>
-  <data name="Settings_ParentalHint" xml:space="preserve">
-    <value>Disable Steam Family restrictions</value>
-  </data>
-  <data name="Settings_ParentalIgnorePlaytime" xml:space="preserve">
-    <value>Ignore Playtime Restrictions</value>
-  </data>
-  <data name="Settings_ParentalIgnorePlaytimeHint" xml:space="preserve">
-    <value>Disables playtime restrictions. Reports time up until the set limit but not beyond it.</value>
-  </data>
-  <data name="Settings_ParentalBypassPlaytime" xml:space="preserve">
-    <value>Disable Family Restrictions</value>
-  </data>
-  <data name="Settings_ParentalBypassPlaytimeHint" xml:space="preserve">
-    <value>No client-side family restrictions are enforced.</value>
-  </data>
   <!-- ═══════════════════════ App Update Banner ═════════════════════════ -->
   <data name="AppUpdate_Skip" xml:space="preserve">
-    <value>Skip</value>
+    <value>跳过</value>
   </data>
   <data name="AppUpdate_UpdateNow" xml:space="preserve">
-    <value>Update Now</value>
+    <value>立即更新</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- News Page                                                           -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="News_WhatsNew" xml:space="preserve">
-    <value>What's new?</value>
+    <value>有什么新内容？</value>
   </data>
   <data name="News_AchievementSync_Title" xml:space="preserve">
-    <value>Achievement and Playtime Sync</value>
+    <value>成就与游戏时长同步</value>
   </data>
   <data name="News_AchievementSync_Description" xml:space="preserve">
-    <value>Achievements and Playtime can now be synced to the cloud! Cross-device play is supported. Works through the normal Steam systems. Enable in Settings if you are interested. Note that this feature is experimental!</value>
+    <value>游戏时长与成就现已支持云端同步，可实现跨设备无缝游玩，依托 Steam 原生机制稳定运行。感兴趣的用户可前往设置页面手动开启。温馨提示：该功能尚处于实验阶段。</value>
   </data>
   <data name="News_SchemaFetching_Title" xml:space="preserve">
-    <value>Achievement Schema Fetching for SteamTools</value>
+    <value>为 SteamTools 获取成就架构</value>
   </data>
   <data name="News_SchemaFetching_Description" xml:space="preserve">
-    <value>CR can now fetch achievement schemas, so games that previously did not display achievements will now display them!</value>
+    <value>CR现已支持读取成就架构，以往不显示成就的游戏现在能够正常展示。</value>
   </data>
   <data name="News_ShowLuaGame_Title" xml:space="preserve">
-    <value>Show Lua Game in Status</value>
+    <value>在状态中显示 Lua 游戏</value>
   </data>
   <data name="News_ShowLuaGame_Description" xml:space="preserve">
-    <value>Lua apps can now appear in your Steam status. They appear as a non-Steam game with the correct game name. This change is on by default, disable in Settings if you don't want it.</value>
+    <value>Lua应用现已可展示在你的Steam状态中，会标注为非Steam游戏并显示正确游戏名。该功能默认开启，无需使用可前往设置关闭。</value>
   </data>
   <data name="News_760CleanUp_Title" xml:space="preserve">
-    <value>760 Clean Up</value>
+    <value>760 清理</value>
   </data>
   <data name="News_760CleanUp_Description" xml:space="preserve">
-    <value>There is a new (experimental) tool that can delete the saves that SteamTools uploaded to AppID 760. Read the release notes on Github for more information.</value>
+    <value>有一个新的（实验性）工具可以删除 SteamTools 上传到 AppID 760 的存档。请阅读 Github 上的发布说明以获取更多信息。</value>
   </data>
   <data name="News_AndMore_Title" xml:space="preserve">
-    <value>...and more!</value>
+    <value>……还有更多！</value>
   </data>
   <data name="News_AndMore_Description" xml:space="preserve">
-    <value>Bug fixes, Google Drive performance improvements, preparation work for future updates, unannounced features sprinkled throughout the CR UI. Fun for all!</value>
+    <value>错误修复、Google Drive 性能改进、未来更新的准备工作、CR UI 中散布的未公开功能。应有尽有！</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- Setup Page                                                          -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Setup_ManifestEndpoint" xml:space="preserve">
-    <value>Manifest Endpoint</value>
+    <value>清单端点</value>
   </data>
   <data name="Setup_ManifestEndpoint_Description" xml:space="preserve">
-    <value>Override the manifest download URL and User-Agent used by SteamTools. Leave empty to use the default.</value>
+    <value>覆盖 SteamTools 使用的清单下载 URL 和 User-Agent。留空则使用默认值。</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- Cloud Provider & Stats                                              -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="CloudProvider_Authenticated" xml:space="preserve">
-    <value>Authenticated</value>
+    <value>已认证</value>
   </data>
   <data name="Stats_LoadingFromCloud" xml:space="preserve">
-    <value>Loading data from cloud...</value>
+    <value>正在从云端加载数据...</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- Settings - Quality of Life                                          -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Settings_AutoUpdate" xml:space="preserve">
-    <value>Auto Update</value>
+    <value>自动更新</value>
   </data>
   <data name="Settings_AutoUpdate_Description" xml:space="preserve">
-    <value>Automatically download latest version of the Cloud Redirect DLL on Steam startup</value>
+    <value>在 Steam 启动时自动下载最新版本的 Cloud Redirect DLL</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- 760 Clean Up Page                                                   -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="Cloud760_Title" xml:space="preserve">
-    <value>760 Clean Up</value>
+    <value>760 清理</value>
   </data>
   <data name="Cloud760_Description" xml:space="preserve">
-    <value>View and delete the saves SteamTools wrote to 760 (Steam Screenshots). This will stop SteamTools from redownloading those saves when run without CloudRedirect patches, preventing SteamTools from contaminating the userdata of each injected game.</value>
+    <value>查看并删除 SteamTools 写入到 760（Steam 截图）的存档。这将阻止 SteamTools 在不使用 CloudRedirect 补丁运行时重新下载这些存档，防止 SteamTools 污染每个注入游戏的用户数据。</value>
   </data>
   <data name="Cloud760_Connect" xml:space="preserve">
-    <value>Connect</value>
+    <value>连接</value>
   </data>
   <data name="Cloud760_Refresh" xml:space="preserve">
-    <value>Refresh</value>
+    <value>刷新</value>
   </data>
   <data name="Cloud760_NoFilesYet" xml:space="preserve">
-    <value>No files yet</value>
+    <value>暂无文件</value>
   </data>
   <data name="Cloud760_NoFilesYet_Description" xml:space="preserve">
-    <value>Connect to load your AppID 760 cloud files. If nothing shows up, open the Steam console, run </value>
+    <value>连接以加载您的 AppID 760 云文件。如果没有显示任何内容，请打开 Steam 控制台，运行 </value>
   </data>
   <data name="Cloud760_ThenRefresh" xml:space="preserve">
-    <value>, then Refresh.</value>
+    <value>，然后刷新。</value>
   </data>
   <data name="Cloud760_OpenConsole" xml:space="preserve">
-    <value>Open Console</value>
+    <value>打开控制台</value>
   </data>
   <data name="Cloud760_CopyCommand" xml:space="preserve">
-    <value>Copy Command</value>
+    <value>复制命令</value>
   </data>
   <data name="Cloud760_SelectAll" xml:space="preserve">
-    <value>Select All</value>
+    <value>全选</value>
   </data>
   <data name="Cloud760_Clear" xml:space="preserve">
-    <value>Clear</value>
+    <value>清除</value>
   </data>
   <data name="Cloud760_DeleteCloudFiles" xml:space="preserve">
-    <value>Delete cloud files</value>
+    <value>删除云文件</value>
   </data>
   <data name="Cloud760_DeleteWarning" xml:space="preserve">
-    <value>Removing files here is permanent and cannot be undone.</value>
+    <value>删除操作是永久性的，无法撤销。</value>
   </data>
   <data name="Cloud760_DeleteSelected" xml:space="preserve">
-    <value>Delete Selected</value>
+    <value>删除所选</value>
   </data>
   <data name="Cloud760_DeleteAll" xml:space="preserve">
-    <value>Delete All</value>
+    <value>全部删除</value>
   </data>
   <data name="Cloud760_FilesSelected" xml:space="preserve">
-    <value>{0} of {1} selected</value>
+    <value>已选择 {0} 个，共 {1} 个</value>
   </data>
   <data name="Cloud760_FilesCount" xml:space="preserve">
-    <value>{0} file(s)</value>
+    <value>{0} 个文件</value>
   </data>
   <data name="Cloud760_ConsoleOpened" xml:space="preserve">
-    <value>Steam console opened. Run 'cloud_sync_up {0}' there, then Connect.</value>
+    <value>Steam 控制台已打开。在其中运行 'cloud_sync_up {0}'，然后点击连接。</value>
   </data>
   <data name="Cloud760_CommandCopied" xml:space="preserve">
-    <value>Copied 'cloud_sync_up {0}' to clipboard. Paste it into the Steam console.</value>
+    <value>已复制 'cloud_sync_up {0}' 到剪贴板。请粘贴到 Steam 控制台中。</value>
   </data>
   <data name="Cloud760_Connecting" xml:space="preserve">
-    <value>Connecting to Steam Cloud as AppID {0}...</value>
+    <value>正在连接到 Steam 云，AppID {0}...</value>
   </data>
   <data name="Cloud760_QuotaUsed" xml:space="preserve">
-    <value>{0} / {1} used</value>
+    <value>已使用 {0} / {1}</value>
   </data>
   <data name="Cloud760_ConnectedNoFiles" xml:space="preserve">
-    <value>Connected to AppID {0}, but no cloud files were found.</value>
+    <value>已连接到 AppID {0}，但未找到云文件。</value>
   </data>
   <data name="Cloud760_Refreshing" xml:space="preserve">
-    <value>Refreshing...</value>
+    <value>正在刷新...</value>
   </data>
   <data name="Cloud760_LoadedFiles" xml:space="preserve">
-    <value>Loaded {0} file(s) for AppID {1}.</value>
+    <value>已为 AppID {1} 加载 {0} 个文件。</value>
   </data>
   <data name="Cloud760_DeletingFiles" xml:space="preserve">
-    <value>Deleting {0} file(s)...</value>
+    <value>正在删除 {0} 个文件...</value>
   </data>
   <data name="Cloud760_DeletedFiles" xml:space="preserve">
-    <value>Deleted {0} file(s)</value>
+    <value>已删除 {0} 个文件</value>
   </data>
   <data name="Cloud760_DeletedFilesFailed" xml:space="preserve">
-    <value>Deleted {0} file(s), {1} failed.</value>
+    <value>已删除 {0} 个文件，{1} 个失败。</value>
   </data>
   <data name="Cloud760_Error" xml:space="preserve">
-    <value>Error: {0}</value>
+    <value>错误：{0}</value>
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <!-- OAuth / Authentication                                              -->
   <!-- ═══════════════════════════════════════════════════════════════════ -->
   <data name="OAuth_Authenticated" xml:space="preserve">
-    <value>Authenticated.</value>
+    <value>已认证。</value>
   </data>
 
 </root>
+
+

--- a/ui/Services/OAuthService.cs
+++ b/ui/Services/OAuthService.cs
@@ -315,7 +315,7 @@ public sealed class OAuthService : IDisposable
             if (!hasRefresh)
                 return new TokenStatus(false, "Token file exists but missing refresh token");
 
-            return new TokenStatus(true, "Authenticated.");
+            return new TokenStatus(true, S.Get("OAuth_Authenticated"));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
# Pull Request Description

## Summary

Add complete Simplified Chinese (zh-CN) translation support for CloudRedirect UI.

## Translation Coverage

This PR adds **45 translation entries** covering all user-facing UI text:

- **News Page** (6 entries): "What's new?", feature announcements, page descriptions
- **Setup Page** (2 entries): "Manifest Endpoint" label and description
- **Settings Page** (2 entries): "Auto Update" option and description
- **Stats Page** (1 entry): Loading status message
- **Cloud760 Page** (25 entries): Complete page translation including title, description, all buttons, status messages, and file operations
- **OAuth Service** (6 entries): Authentication success/failure page titles and messages
- **Delete Confirmations** (3 entries): File deletion confirmation dialogs

## Modified Files (9 files)

### Resource Files (2 files)
- `ui/Resources/Strings.resx` - Added 45 English resource keys
- `ui/Resources/Strings.zh-CN.resx` - Added 45 Chinese translations (new file)

### XAML Files (4 files)
- `ui/Pages/NewsPage.xaml` - Replaced 6 hardcoded text strings
- `ui/Pages/SetupPage.xaml` - Replaced 2 hardcoded text strings
- `ui/Pages/SettingsPage.xaml` - Replaced 2 hardcoded text strings
- `ui/Pages/Cloud760Page.xaml` - Replaced 11 hardcoded text strings

### C# Code Files (3 files)
- `ui/Pages/StatsPage.xaml.cs` - Replaced 1 hardcoded string, added `using CloudRedirect.Resources;`
- `ui/Pages/Cloud760Page.xaml.cs` - Localized all dynamic status messages using `S.Get()` and `S.Format()`
- `ui/Services/OAuthService.cs` - Replaced authentication status string

## Implementation Details

- **XAML localization**: Used `{res:Loc KeyName}` markup extension for static text
- **C# localization**: Used `S.Get("KeyName")` for simple strings and `S.Format("KeyName", args...)` for formatted messages
- **Follows existing patterns**: Matches the localization approach used for Spanish (es) and Portuguese (pt-BR) translations
- **No functional changes**: Pure translation work, all original behavior preserved
- **UI layout preserved**: All Chinese text fits properly in existing UI elements

## Code Changes Summary

```diff
9 files changed, 2214 insertions(+), 47 deletions(-)
```

- **+2,214 lines**: Primarily from new `Strings.zh-CN.resx` file
- **-47 lines**: Hardcoded text replaced with resource references

## Testing

✅ **Build**: Compiles successfully with no warnings  
✅ **Runtime**: Tested on Windows 11 with Chinese language setting  
✅ **UI Pages**: All pages display correctly in Chinese  
✅ **Dynamic Messages**: Status messages and confirmations work as expected  
✅ **Language Switching**: Can switch between English and Chinese via Settings → Language

## Known Limitations

⚠️ **C++ tool error messages** remain untranslated:
- Error messages from `cloud760_tool.exe` (e.g., "SteamAPI_Init failed for AppID 760...") are generated by the C++ component in `src/platform/win/cloud760_tool.cpp`
- Translating these would require modifying and recompiling the C++ code
- This is beyond the scope of this translation-focused PR

## Checklist

- [x] All user-facing text replaced with localized resource keys
- [x] Translation keys follow existing naming conventions (`Page_Element` pattern)
- [x] No functional changes introduced
- [x] Build passes without errors or warnings
- [x] Tested with Chinese language setting
- [x] UI layout remains intact with Chinese text

## Additional Notes

This translation enables CloudRedirect to be fully usable for Chinese-speaking users, matching the quality of existing Spanish and Portuguese translations.
