### PR TITLE
Linux: follow full redirect chain on token-stripped download (fixes personal OneDrive 302)

### DIFF
--- a/src/platform/linux/http_transport_linux.cpp
+++ b/src/platform/linux/http_transport_linux.cpp
@@ -30,6 +30,7 @@ typedef int CURLoption;
 #define CURLOPT_CONNECTTIMEOUT 78
 #define CURLOPT_USERAGENT      10018
 #define CURLOPT_FOLLOWLOCATION 52
+#define CURLOPT_MAXREDIRS      68
 #define CURLOPT_HEADERFUNCTION 20079
 #define CURLOPT_HEADERDATA     10029
 #define CURLINFO_RESPONSE_CODE 0x200002
@@ -160,7 +161,8 @@ static HttpUtil::HttpResp CurlRequest(const char* logTag, const char* method,
                                        const std::string& url, const std::string& body,
                                        const std::vector<std::string>& hdrs,
                                        long timeout, bool captureHeaders,
-                                       std::string* outLocation) {
+                                       std::string* outLocation,
+                                       bool followRedirects = false) {
     HttpUtil::HttpResp resp;
 
     if (!InitCurl()) {
@@ -197,7 +199,14 @@ static HttpUtil::HttpResp CurlRequest(const char* logTag, const char* method,
     g_curl.easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
     g_curl.easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
     g_curl.easy_setopt(curl, CURLOPT_USERAGENT, "CloudRedirect/1.0");
-    g_curl.easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
+    // Only follow redirects when the caller sends no auth header (token must
+    // never be forwarded to a redirect target). OneDrive personal chains
+    // 302s (graph -> microsoftpersonalcontent -> sharepoint CDN), so a single
+    // manual hop is not enough; WinHTTP on Windows follows the tail of the
+    // chain automatically and this mirrors that behavior.
+    g_curl.easy_setopt(curl, CURLOPT_FOLLOWLOCATION, followRedirects ? 1L : 0L);
+    if (followRedirects)
+        g_curl.easy_setopt(curl, CURLOPT_MAXREDIRS, 10L);
 
     if (captureHeaders) {
         g_curl.easy_setopt(curl, CURLOPT_HEADERFUNCTION, (void*)HeaderCallback);
@@ -277,7 +286,8 @@ public:
         std::string location;
         auto resp = CurlRequest(m_logTag, "GET", url, {}, hdrs, 30L, true, &location);
         if (resp.status >= 300 && resp.status < 400 && !location.empty())
-            return CurlRequest(m_logTag, "GET", location, {}, {}, 60L, false, nullptr);
+            return CurlRequest(m_logTag, "GET", location, {}, {}, 60L, false, nullptr,
+                               /*followRedirects=*/true);
         return resp;
     }
 


### PR DESCRIPTION
## Problem

On Linux with a **personal** OneDrive, every download fails with `failed HTTP 302`, which also stalls uploads (the client can't read `state.cloudredirect`, so it never signals changes). `/content` now returns a two-hop redirect chain:

```
graph.microsoft.com/.../content
  -> 302 my.microsoftpersonalcontent.com/.../download.aspx?...tempauth=...
  -> 302 <region>.gr.global.aa-rt.sharepoint.com/.../download.aspx?...
  -> 200 (content)
```

`AuthenticatedGetWithRedirect` strips the Bearer token and follows the first 302 manually, but the follow request has `CURLOPT_FOLLOWLOCATION=0`, so it stops at the second 302 and returns it verbatim. `DownloadFileById` then sees a non-200 and fails. Windows (WinHTTP) and rclone follow the tail of the chain automatically, which is why only the Linux transport is affected.

## Fix

Add an opt-in `followRedirects` param to `CurlRequest`. On the **tokenless** post-strip request, set `CURLOPT_FOLLOWLOCATION=1` + `CURLOPT_MAXREDIRS=10`. The Bearer token still only travels on hop 0 (unchanged), so nothing is forwarded to a redirect target. This mirrors WinHTTP's default behavior on Windows.

Single file changed: `src/platform/linux/http_transport_linux.cpp`.

## Testing

Built 32-bit (`cmake -DLINUX_32BIT=ON`, g++-12-multilib) and deployed on a Steam Deck against personal OneDrive:
- `failed HTTP 302`: from ~1 every 62s to **0** after deploy.
- Downloads of `state.cloudredirect` / `stats.json` / `cn` now succeed; `INCONCLUSIVE cloud fetch` gone.
- Full E2E with Cuphead (268910): launch-sync pulls state, exit-sync uploads `state`/`cn`/`stats` and publishes the new change number; confirmed independently via rclone (timestamps written by the Deck).
- Local save unchanged (identical md5 vs pre-change backup).