### PR TITLE
fix: add ~/.steam/debian-installation/ to Steam path detection

### DIFF
--- a/src/platform/linux/cloud_intercept.cpp
+++ b/src/platform/linux/cloud_intercept.cpp
@@ -35,6 +35,8 @@ static std::string DetectSteamPath() {
     if (std::filesystem::is_directory(path)) return path;
     path = home + "/.var/app/com.valvesoftware.Steam/.local/share/Steam/";
     if (std::filesystem::is_directory(path)) return path;
+    path = home + "/.steam/debian-installation/";
+    if (std::filesystem::is_directory(path)) return path;
     path = home + "/.steam/steam/";
     if (std::filesystem::is_directory(path)) return path;
     return home + "/.local/share/Steam/";


### PR DESCRIPTION
## Problem

`DetectSteamPath()` in `src/platform/linux/cloud_intercept.cpp` currently searches these directories (in order):

1. `~/.local/share/Steam/`
2. `~/.var/app/com.valvesoftware.Steam/.local/share/Steam/`
3. `~/.steam/steam/`

On **Debian/Ubuntu** systems (and derivatives like Linux Mint, Pop!_OS, etc.), the Steam package installs to `~/.steam/debian-installation/` by default. This path is not in the detection list.

When the path is not found, `LoadAccountIdFromLoginUsers()` fails to open `loginusers.vdf`, leaving `accountId` at 0. Every cloud hook then checks:

```cpp
uint32_t accountId = CloudIntercept::GetAccountId();
if (accountId == 0) {
    return origFn(...);  // falls through to Steam's own cloud
}
```

This effectively **disables CloudRedirect** for all namespace apps — cloud RPCs pass straight through to Steam servers, which return `Upload Access Denied` for apps that the user doesn't own.

## Fix

Add `~/.steam/debian-installation/` as a fallback between the Flatpak path and `~/.steam/steam/`. The path is only used when the directory exists, so no change in behavior for other distros.

The detection order becomes:

1. `~/.local/share/Steam/` (XDG default)
2. `~/.var/app/com.valvesoftware.Steam/.local/share/Steam/` (Flatpak)
3. **`~/.steam/debian-installation/`** (Debian/Ubuntu package)
4. `~/.steam/steam/` (manual/other)

## Testing

Confirmed on a Debian-based system where `~/.steam/debian-installation/` is the active Steam directory. After applying this fix, `accountId` bootstraps correctly from `loginusers.vdf` and CloudRedirect intercepts cloud RPCs as expected.