### PR TITLE
feat: add custom AutoCloud rules for unmanaged games

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(COMMON_SOURCES
     src/common/cli.cpp
     src/common/cloud_provider_base.cpp
     src/common/autocloud_scan.cpp
+    src/common/custom_autocloud.cpp
     src/common/steam_kv_injector.cpp
     src/common/parental_bypass.cpp
     src/common/metadata_sync.cpp
@@ -214,6 +215,24 @@ endif()
 # ── Tests ───────────────────────────────────────────────────────────────
 
 enable_testing()
+
+add_executable(custom_autocloud_tests
+    src/common/custom_autocloud_tests.cpp
+    src/common/custom_autocloud.cpp
+    src/common/json.cpp
+)
+target_include_directories(custom_autocloud_tests PRIVATE src/common)
+target_compile_definitions(custom_autocloud_tests PRIVATE CLOUDREDIRECT_TESTING)
+if(WIN32)
+    target_include_directories(custom_autocloud_tests PRIVATE src/platform/win)
+    target_sources(custom_autocloud_tests PRIVATE src/platform/win/log.cpp)
+    target_link_libraries(custom_autocloud_tests PRIVATE Shell32)
+else()
+    target_include_directories(custom_autocloud_tests PRIVATE src/platform/linux)
+    target_sources(custom_autocloud_tests PRIVATE src/platform/linux/log.cpp)
+    target_link_libraries(custom_autocloud_tests PRIVATE pthread)
+endif()
+add_test(NAME custom_autocloud_tests COMMAND custom_autocloud_tests)
 
 if(EXISTS ${CMAKE_SOURCE_DIR}/tests/autocloud_native_tests.cpp)
     add_compile_definitions(CR_RELEASE_VERSION="${CR_RELEASE_VERSION}")

--- a/src/common/autocloud_scan.cpp
+++ b/src/common/autocloud_scan.cpp
@@ -1,4 +1,5 @@
 #include "autocloud_scan.h"
+#include "custom_autocloud.h"
 #include "autocloud_util.h"
 #include "file_util.h"
 #include "log.h"
@@ -629,6 +630,10 @@ ScanResult GetFileList(const std::string& steamPath,
 
     auto rules = LoadAutoCloudRules(steamPath, appId, effectivePlatform);
     if (rules.empty()) {
+        rules = CustomAutoCloud::GetRules(appId);
+        if (!rules.empty()) LOG("[CustomAutoCloud] app %u using %zu custom rule(s)", appId, rules.size());
+    }
+    if (rules.empty()) {
         LOG("GetAutoCloudFileList: no appinfo UFS save rules for app %u", appId);
         outResult.complete = true; // no rules = nothing to scan, trivially complete
         return outResult;
@@ -1112,7 +1117,8 @@ ScanResult GetFileList(const std::string& steamPath,
 std::vector<AutoCloudUtil::AutoCloudRuleNative> GetRules(
     const std::string& steamPath, uint32_t appId, uint32_t accountId) {
     (void)accountId;
-    return LoadAutoCloudRules(steamPath, appId, AutoCloudEffectivePlatform::Current);
+    auto rules = LoadAutoCloudRules(steamPath, appId, AutoCloudEffectivePlatform::Current);
+    return rules.empty() ? CustomAutoCloud::GetRules(appId) : rules;
 }
 
 // GetRootOverrides - exposes raw rootoverrides for cross-platform mapping

--- a/src/common/custom_autocloud.cpp
+++ b/src/common/custom_autocloud.cpp
@@ -1,0 +1,371 @@
+#include "custom_autocloud.h"
+#include "json.h"
+#include "log.h"
+#include "steam_root_ids.h"
+#include "autocloud_scan.h"
+#include "cloud_intercept.h"
+#include "cloud_storage.h"
+#include "local_storage.h"
+#include "manifest_store.h"
+#include "file_util.h"
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <sstream>
+#include <thread>
+#include <unordered_set>
+#include <chrono>
+#include <ctime>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace {
+constexpr uintmax_t kMaxConfigBytes = 1024 * 1024;
+constexpr size_t kMaxRulesPerApp = 64;
+constexpr size_t kMaxFieldBytes = 512;
+
+bool SafeRelative(const std::string& value) {
+    if (value.empty() || value.size() > kMaxFieldBytes) return false;
+    if (value[0] == '/' || value[0] == '\\') return false;
+    if (value.size() > 1 && std::isalpha((unsigned char)value[0]) && value[1] == ':') return false;
+    std::string part;
+    for (size_t i = 0; i <= value.size(); ++i) {
+        char c = i < value.size() ? value[i] : '/';
+        if (c == '/' || c == '\\') {
+            if (part == "..") return false;
+            part.clear();
+        } else {
+            part.push_back(c);
+        }
+    }
+    return true;
+}
+
+bool SafePattern(const std::string& value) {
+    return SafeRelative(value) && value.find('/') == std::string::npos &&
+           value.find('\\') == std::string::npos && value != "." && value != "..";
+}
+
+const SteamRootIds::Entry* FindRoot(const std::string& root) {
+    for (const auto& entry : SteamRootIds::kEntries) {
+        if (root == entry.bareName) return &entry;
+    }
+    return nullptr;
+}
+
+std::vector<AutoCloudUtil::AutoCloudRuleNative> Parse(
+    const std::string& text, uint32_t appId, std::string* error) {
+    auto fail = [&](const std::string& message) {
+        if (error) *error = message;
+        return std::vector<AutoCloudUtil::AutoCloudRuleNative>{};
+    };
+    if (appId == 0) return fail("invalid app id");
+    Json::Value root = Json::Parse(text);
+    if (root.type != Json::Type::Object) return fail("config is not an object");
+    const auto& all = root["custom_autocloud"];
+    if (all.type == Json::Type::Null) return {};
+    if (all.type != Json::Type::Object) return fail("custom_autocloud is not an object");
+    const auto& app = all[std::to_string(appId)];
+    if (app.type == Json::Type::Null) return {};
+    if (app.type != Json::Type::Object) return fail("app entry is not an object");
+    const auto& strategy = app["strategy"];
+    if (strategy.type != Json::Type::String || strategy.str() != "steam-first")
+        return fail("unsupported strategy");
+    const auto& list = app["rules"];
+    if (list.type != Json::Type::Array || list.size() == 0 || list.size() > kMaxRulesPerApp)
+        return fail("invalid rule count");
+
+    std::vector<AutoCloudUtil::AutoCloudRuleNative> rules;
+    for (const auto& value : list.arrVal) {
+        if (value.type != Json::Type::Object) return fail("rule is not an object");
+        const auto& rootValue = value["root"];
+        const auto& path = value["path"];
+        const auto& pattern = value["pattern"];
+        const auto& recursive = value["recursive"];
+        if (rootValue.type != Json::Type::String || path.type != Json::Type::String ||
+            pattern.type != Json::Type::String || recursive.type != Json::Type::Bool)
+            return fail("rule fields have invalid types");
+        const auto* knownRoot = FindRoot(rootValue.str());
+        if (!knownRoot || !SafeRelative(path.str()) || !SafePattern(pattern.str()))
+            return fail("unsafe or unsupported rule");
+        AutoCloudUtil::AutoCloudRuleNative rule;
+        rule.root = knownRoot->bareName;
+        rule.cloudRoot = knownRoot->token;
+        rule.path = path.str();
+        rule.resolvedPath = rule.path;
+        rule.pattern = pattern.str();
+        rule.recursive = recursive.boolean();
+        rules.push_back(std::move(rule));
+    }
+    return rules;
+}
+
+std::filesystem::path ConfigPath() {
+#ifdef _WIN32
+    wchar_t buffer[32768];
+    DWORD n = GetEnvironmentVariableW(L"APPDATA", buffer, 32768);
+    if (n > 0 && n < 32768) return std::filesystem::path(buffer) / L"CloudRedirect" / L"config.json";
+#else
+    if (const char* xdg = std::getenv("XDG_CONFIG_HOME"))
+        return std::filesystem::path(xdg) / "CloudRedirect" / "config.json";
+    if (const char* home = std::getenv("HOME"))
+        return std::filesystem::path(home) / ".config" / "CloudRedirect" / "config.json";
+#endif
+    return {};
+}
+
+#ifndef CLOUDREDIRECT_TESTING
+std::mutex g_sessionMutex;
+std::unordered_set<uint32_t> g_runningApps;
+std::unordered_set<uint32_t> g_rpcApps;
+struct SessionBase {
+    std::unordered_map<std::string, std::vector<uint8_t>> local;
+    CloudStorage::Manifest store;
+};
+std::unordered_map<uint32_t, SessionBase> g_sessionBases;
+
+std::unordered_map<std::string, std::vector<uint8_t>> LocalHashes(uint32_t appId) {
+    std::unordered_map<std::string, std::vector<uint8_t>> result;
+    auto scan = AutoCloudScan::GetFileList(CloudIntercept::GetSteamPath(),
+        CloudIntercept::GetAccountId(), appId);
+    if (!scan.complete) return result;
+    for (const auto& file : scan.files) result[file.relativePath] = file.sha;
+    return result;
+}
+
+bool StoreMatchesLocal(const CloudStorage::Manifest& store,
+                       const std::unordered_map<std::string, std::vector<uint8_t>>& local) {
+    if (store.size() != local.size()) return false;
+    for (const auto& [name, sha] : local) {
+        auto it = store.find(name);
+        if (it == store.end() || it->second.sha != sha) return false;
+    }
+    return true;
+}
+
+bool StoresEqual(const CloudStorage::Manifest& a, const CloudStorage::Manifest& b) {
+    if (a.size() != b.size()) return false;
+    for (const auto& [name, value] : a) {
+        auto it = b.find(name);
+        if (it == b.end() || it->second.sha != value.sha ||
+            it->second.timestamp != value.timestamp || it->second.size != value.size) return false;
+    }
+    return true;
+}
+
+bool RestoreManaged(uint32_t appId, const CloudStorage::Manifest& store) {
+    auto rules = CustomAutoCloud::GetRules(appId);
+    if (rules.empty()) return false;
+    auto roots = AutoCloudScan::GetRootTokenDirectories(CloudIntercept::GetSteamPath(), appId,
+        CloudIntercept::GetAccountId());
+    auto root = roots.find(rules.front().cloudRoot);
+    if (root == roots.end() || root->second.empty()) return false;
+    for (const auto& [name, entry] : store) {
+        if (!SafeRelative(name)) return false;
+        bool found = false;
+        auto bytes = CloudStorage::RetrieveBlob(CloudIntercept::GetAccountId(), appId, name, &found);
+        if (!found || FileUtil::SHA1(bytes.data(), bytes.size()) != entry.sha) return false;
+        auto target = std::filesystem::path(root->second) / FileUtil::Utf8ToPath(name);
+        std::error_code ec;
+        std::filesystem::create_directories(target.parent_path(), ec);
+        if (ec) return false;
+        if (!FileUtil::AtomicWriteBinary(FileUtil::PathToUtf8(target),
+                bytes.empty() ? nullptr : bytes.data(), bytes.size())) return false;
+    }
+    return true;
+}
+
+void WriteStatus(uint32_t appId, const char* state, const char* mode,
+                 size_t fileCount, const std::string& error = {}) {
+    auto config = ConfigPath();
+    if (config.empty()) return;
+    auto path = config.parent_path() / "custom_autocloud_status.json";
+    static std::mutex statusMutex;
+    std::lock_guard<std::mutex> lock(statusMutex);
+    Json::Value root = Json::Object();
+    std::ifstream current(path, std::ios::binary);
+    if (current) {
+        std::string text((std::istreambuf_iterator<char>(current)), {});
+        auto parsed = Json::Parse(text);
+        if (parsed.type == Json::Type::Object) root = std::move(parsed);
+    }
+    Json::Value status = Json::Object();
+    status.objVal["state"] = Json::String(state);
+    status.objVal["mode"] = Json::String(mode);
+    status.objVal["file_count"] = Json::Number((double)fileCount);
+    status.objVal["last_capture_time"] = Json::Number((double)std::time(nullptr));
+    status.objVal["error"] = Json::String(error);
+    root.objVal[std::to_string(appId)] = std::move(status);
+    std::error_code ec;
+    std::filesystem::create_directories(path.parent_path(), ec);
+    FileUtil::AtomicWriteText(FileUtil::PathToUtf8(path), Json::Stringify(root) + "\n");
+}
+
+void ManagedCapture(uint32_t appId) {
+    {
+        std::lock_guard<std::mutex> lock(g_sessionMutex);
+        if (g_rpcApps.count(appId)) return;
+    }
+    uint32_t accountId = CloudIntercept::GetAccountId();
+    std::string steamPath = CloudIntercept::GetSteamPath();
+    if (accountId == 0 || steamPath.empty()) {
+        WriteStatus(appId, "error", "managed", 0, "Steam account or path unavailable");
+        return;
+    }
+    auto scan = AutoCloudScan::GetFileList(steamPath, accountId, appId);
+    if (!scan.hasRules) return;
+    if (!scan.complete) {
+        WriteStatus(appId, scan.hasRootCollision ? "conflict" : "error", "managed", 0,
+                    scan.hasRootCollision ? "root collision" : "incomplete scan");
+        return;
+    }
+    if (scan.files.empty()) {
+        WriteStatus(appId, "configured", "managed", 0);
+        return;
+    }
+    size_t stored = 0;
+    for (const auto& file : scan.files) {
+        std::ifstream input(FileUtil::Utf8ToPath(file.fullPath), std::ios::binary);
+        if (!input) {
+            WriteStatus(appId, "error", "managed", stored, "save changed during capture");
+            return;
+        }
+        std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(input)), {});
+        auto sha = FileUtil::SHA1(bytes.data(), bytes.size());
+        if (sha != file.sha || !CloudStorage::StoreBlob(accountId, appId, file.relativePath,
+                bytes.empty() ? nullptr : bytes.data(), bytes.size()) ||
+            !CloudStorage::UpdateManifestEntry(accountId, appId, file.relativePath,
+                sha, file.modifiedTime, bytes.size())) {
+            WriteStatus(appId, "error", "managed", stored, "atomic publish failed");
+            return;
+        }
+        ++stored;
+    }
+    uint64_t cn = LocalStorage::IncrementChangeNumber(accountId, appId);
+    CloudStorage::SaveManifestSnapshot(accountId, appId, cn);
+    WriteStatus(appId, "active", "managed", stored);
+}
+#endif
+} // namespace
+
+namespace CustomAutoCloud {
+std::vector<AutoCloudUtil::AutoCloudRuleNative> GetRules(uint32_t appId) {
+    auto path = ConfigPath();
+    if (path.empty()) return {};
+    std::error_code ec;
+    auto size = std::filesystem::file_size(path, ec);
+    if (ec || size > kMaxConfigBytes) return {};
+    auto mtime = std::filesystem::last_write_time(path, ec);
+    if (ec) return {};
+    static std::mutex mutex;
+    static std::filesystem::file_time_type cachedMtime;
+    static uintmax_t cachedSize = static_cast<uintmax_t>(-1);
+    static std::string cachedText;
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (mtime != cachedMtime || size != cachedSize) {
+            std::ifstream input(path, std::ios::binary);
+            if (!input) return {};
+            cachedText.assign(std::istreambuf_iterator<char>(input), {});
+            cachedMtime = mtime;
+            cachedSize = size;
+        }
+        std::string error;
+        auto rules = Parse(cachedText, appId, &error);
+        if (!error.empty()) LOG("[CustomAutoCloud] app %u rejected: %s", appId, error.c_str());
+        return rules;
+    }
+}
+
+#ifndef CLOUDREDIRECT_TESTING
+void ObserveSteamRpc(uint32_t appId) {
+    if (GetRules(appId).empty()) return;
+    std::lock_guard<std::mutex> lock(g_sessionMutex);
+    g_rpcApps.insert(appId);
+    WriteStatus(appId, "active", "steam", 0);
+}
+
+void ObserveGamesPlayed(const std::unordered_set<uint32_t>& appIds) {
+    std::vector<uint32_t> started, ended;
+    {
+        std::lock_guard<std::mutex> lock(g_sessionMutex);
+        for (uint32_t appId : appIds)
+            if (!GetRules(appId).empty() && g_runningApps.insert(appId).second) started.push_back(appId);
+        for (uint32_t appId : g_runningApps)
+            if (!appIds.count(appId)) ended.push_back(appId);
+        for (uint32_t appId : ended) g_runningApps.erase(appId);
+        for (uint32_t appId : started) g_rpcApps.erase(appId);
+    }
+    for (uint32_t appId : started) {
+        WriteStatus(appId, "configured", "managed", 0);
+        std::thread([appId]{
+            SessionBase base;
+            base.local = LocalHashes(appId);
+            base.store = CloudStorage::LoadLocalManifest(CloudIntercept::GetAccountId(), appId);
+            {
+                std::lock_guard<std::mutex> lock(g_sessionMutex);
+                g_sessionBases[appId] = base;
+            }
+            if (base.store.empty()) {
+                ManagedCapture(appId); // first adoption
+                base.store = CloudStorage::LoadLocalManifest(CloudIntercept::GetAccountId(), appId);
+                std::lock_guard<std::mutex> lock(g_sessionMutex);
+                g_sessionBases[appId] = base;
+            } else if (base.local.empty()) {
+                if (RestoreManaged(appId, base.store)) {
+                    base.local = LocalHashes(appId);
+                    std::lock_guard<std::mutex> lock(g_sessionMutex);
+                    g_sessionBases[appId] = base;
+                    WriteStatus(appId, "active", "managed", base.store.size());
+                } else {
+                    WriteStatus(appId, "error", "managed", base.store.size(), "restore failed");
+                }
+            } else if (!StoreMatchesLocal(base.store, base.local)) {
+                WriteStatus(appId, "conflict", "managed", base.store.size(),
+                    "local and CloudRedirect data have no common base");
+            } else {
+                WriteStatus(appId, "active", "managed", base.store.size());
+            }
+        }).detach();
+    }
+    for (uint32_t appId : ended) {
+        std::thread([appId]{
+            std::this_thread::sleep_for(std::chrono::seconds(3));
+            SessionBase base;
+            {
+                std::lock_guard<std::mutex> lock(g_sessionMutex);
+                auto it = g_sessionBases.find(appId);
+                if (it == g_sessionBases.end()) return;
+                base = it->second;
+                g_sessionBases.erase(it);
+                if (g_rpcApps.count(appId)) return;
+            }
+            auto local = LocalHashes(appId);
+            auto store = CloudStorage::LoadLocalManifest(CloudIntercept::GetAccountId(), appId);
+            bool localChanged = local != base.local;
+            bool storeChanged = !StoresEqual(store, base.store);
+            if (localChanged && storeChanged) {
+                WriteStatus(appId, "conflict", "managed", store.size(),
+                    "both local and CloudRedirect data changed");
+            } else if (localChanged) {
+                ManagedCapture(appId);
+            } else {
+                WriteStatus(appId, "active", "managed", store.size());
+            }
+        }).detach();
+    }
+}
+#endif
+
+#ifdef CLOUDREDIRECT_TESTING
+std::vector<AutoCloudUtil::AutoCloudRuleNative> ParseConfig(
+    const std::string& json, uint32_t appId, std::string* error) {
+    return Parse(json, appId, error);
+}
+#endif
+} // namespace CustomAutoCloud

--- a/src/common/custom_autocloud.h
+++ b/src/common/custom_autocloud.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "autocloud_util.h"
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <unordered_set>
+
+namespace CustomAutoCloud {
+
+// Loads a validated app entry from config.json. The file is checked on every call;
+// parsed content is reused until its size or modification time changes.
+std::vector<AutoCloudUtil::AutoCloudRuleNative> GetRules(uint32_t appId);
+
+// GamesPlayed lifecycle for apps with custom rules. A real Steam cloud RPC wins
+// for the entire session and suppresses managed capture.
+void ObserveGamesPlayed(const std::unordered_set<uint32_t>& appIds);
+void ObserveSteamRpc(uint32_t appId);
+
+#ifdef CLOUDREDIRECT_TESTING
+std::vector<AutoCloudUtil::AutoCloudRuleNative> ParseConfig(
+    const std::string& json, uint32_t appId, std::string* error = nullptr);
+#endif
+
+} // namespace CustomAutoCloud

--- a/src/common/custom_autocloud_tests.cpp
+++ b/src/common/custom_autocloud_tests.cpp
@@ -1,0 +1,27 @@
+#include "custom_autocloud.h"
+#include <cstdlib>
+#include <iostream>
+
+static void Check(bool value, const char* message) {
+    if (!value) { std::cerr << message << std::endl; std::exit(1); }
+}
+
+int main() {
+    std::string error;
+    auto good = CustomAutoCloud::ParseConfig(R"({
+      "custom_autocloud":{"3751950":{"managed_by":"cargodeck","strategy":"steam-first",
+      "rules":[{"root":"GameInstall","path":"saves","pattern":"*.save","recursive":true}]}}
+    })", 3751950, &error);
+    Check(error.empty() && good.size() == 1, "valid rule rejected");
+    Check(good[0].root == "GameInstall" && good[0].pattern == "*.save", "valid rule changed");
+
+    for (const char* bad : {
+        R"({"custom_autocloud":{"1":{"strategy":"steam-first","rules":[{"root":"GameInstall","path":"../saves","pattern":"*.save","recursive":true}]}}})",
+        R"({"custom_autocloud":{"1":{"strategy":"steam-first","rules":[{"root":"Unknown","path":"saves","pattern":"*.save","recursive":true}]}}})",
+        R"({"custom_autocloud":{"1":{"strategy":"steam-first","rules":[{"root":"GameInstall","path":"saves","pattern":"../*.save","recursive":true}]}}})"
+    }) {
+        error.clear();
+        Check(CustomAutoCloud::ParseConfig(bad, 1, &error).empty() && !error.empty(), "unsafe rule accepted");
+    }
+    return 0;
+}

--- a/src/common/rpc_handlers.cpp
+++ b/src/common/rpc_handlers.cpp
@@ -2,6 +2,7 @@
 #include "metadata_sync.h"
 #include "autocloud_scan.h"
 #include "autocloud_util.h"
+#include "custom_autocloud.h"
 #include "batch_tracker.h"
 #include "cloud_intercept.h"
 #include "local_storage.h"
@@ -546,6 +547,7 @@ static std::string GetMachineName() {
 
 // Returns the blob-store file list; Steam compares vs. remotecache.vdf.
 RpcResult HandleGetChangelist(uint32_t appId, const std::vector<PB::Field>& reqBody) {
+    CustomAutoCloud::ObserveSteamRpc(appId);
     SetRpcCrashContext("GetChangelist:entry", "Cloud.GetAppFileChangelist#1", appId);
     auto* cnField = PB::FindField(reqBody, 2);
     uint64_t clientChangeNumber = cnField ? cnField->varintVal : 0;

--- a/src/common/stats_handlers.cpp
+++ b/src/common/stats_handlers.cpp
@@ -3,6 +3,7 @@
 #include "metadata_sync.h"
 #include "protobuf.h"
 #include "log.h"
+#include "custom_autocloud.h"
 
 #include <cstring>
 #include <mutex>
@@ -306,6 +307,7 @@ void ObserveGamesPlayed(const uint8_t* body, size_t bodyLen) {
     auto fields = PB::Parse(body, bodyLen);
 
     std::unordered_set<uint32_t> currentApps;
+    std::unordered_set<uint32_t> allApps;
 
     for (auto& f : fields) {
         if (f.fieldNum == 1 && f.wireType == PB::LengthDelimited) {
@@ -314,6 +316,7 @@ void ObserveGamesPlayed(const uint8_t* body, size_t bodyLen) {
             if (gameIdField) {
                 uint64_t gameId = gameIdField->varintVal;
                 uint32_t appId = (uint32_t)(gameId & 0xFFFFFF);
+                if (appId != 0) allApps.insert(appId);
                 // Only track namespace/lua apps. Real owned games keep their
                 // server-side playtime; we must never record or sync theirs.
                 if (appId != 0 && IsNamespaceApp(appId)) {
@@ -322,6 +325,8 @@ void ObserveGamesPlayed(const uint8_t* body, size_t bodyLen) {
             }
         }
     }
+    CustomAutoCloud::ObserveGamesPlayed(allApps);
+    if (!MetadataSync::syncPlaytime.load(std::memory_order_relaxed)) return;
 
     std::lock_guard<std::mutex> lock(g_sessionMutex);
 

--- a/src/common/stats_store.cpp
+++ b/src/common/stats_store.cpp
@@ -1,4 +1,7 @@
 #include "stats_store.h"
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 #include "json.h"
 #include "vdf.h"
 #include "log.h"

--- a/src/platform/linux/gamesplayed_hook.cpp
+++ b/src/platform/linux/gamesplayed_hook.cpp
@@ -85,7 +85,7 @@ extern "C" int GamesPlayedHook_OnSend(int cmInterface, void* msg) {
                               emsg == EMSG_GAMES_PLAYED_WITH_DATABLOB);
         bool isStoreStats = (emsg == EMSG_STORE_USER_STATS2);
 
-        if ((isGamesPlayed && MetadataSync::syncPlaytime.load(std::memory_order_relaxed)) ||
+        if (isGamesPlayed ||
             (isStoreStats && MetadataSync::syncAchievements.load(std::memory_order_relaxed))) {
             void* bodyObj = *(void**)((uint8_t*)msg + OFF_BODY);
             if (bodyObj) {

--- a/src/platform/win/cloud_intercept.cpp
+++ b/src/platform/win/cloud_intercept.cpp
@@ -5569,14 +5569,13 @@ static uint8_t __fastcall BAsyncSendHook(void* pMsg, uint32_t connHandle) {
 
             void* bodyObj = *(void**)((uintptr_t)pMsg + CPROTOBUFMSG_OFF_BODY);
             if (bodyObj) {
-                // Observe games-played for playtime session tracking (gated by sync_playtime).
-                if (MetadataSync::PlaytimeEnabled()) {
-                    auto observeBytes = SerializeBodyToBytes(bodyObj);
-                    if (!observeBytes.empty()) {
-                        LOG("[Stats] GamesPlayed observed (emsg=%u, %zu bytes) -> session tracking",
-                            emsg, observeBytes.size());
-                        StatsHandlers::ObserveGamesPlayed(observeBytes.data(), observeBytes.size());
-                    }
+                // Observe unconditionally: custom AutoCloud uses the same lifecycle even
+                // when optional playtime synchronization is disabled.
+                auto observeBytes = SerializeBodyToBytes(bodyObj);
+                if (!observeBytes.empty()) {
+                    LOG("[Stats] GamesPlayed observed (emsg=%u, %zu bytes) -> session tracking",
+                        emsg, observeBytes.size());
+                    StatsHandlers::ObserveGamesPlayed(observeBytes.data(), observeBytes.size());
                 }
                 // Non-Steam-game spoof (hard-gated to ST clients).
                 if (g_showNonSteamGame.load(std::memory_order_relaxed) &&


### PR DESCRIPTION
## Summary

Adds an upstream configuration interface for games that have no publisher AutoCloud rules. External managers can add validated, per-AppID rules under `custom_autocloud`; publisher `appinfo.vdf` rules always retain precedence.

## Configuration

```json
{
  "custom_autocloud": {
    "3751950": {
      "managed_by": "cargodeck",
      "strategy": "steam-first",
      "rules": [{
        "root": "GameInstall",
        "path": "saves",
        "pattern": "*.save",
        "recursive": true
      }]
    }
  }
}
```

## Behavior

- Rejects invalid AppIDs, unsupported roots, absolute/traversing paths, unsafe patterns, oversized configs, and excessive rule counts.
- Hot-reloads rules when `config.json` changes.
- Feeds custom rules through the existing AutoCloud scanner and Steam KV injection path only when publisher rules are absent.
- Uses GamesPlayed start/stop events for managed first-import, empty-local restore, settled exit capture, and session-baseline conflict detection.
- Suppresses managed capture after a real Steam cloud changelist RPC is observed.
- Refuses publication after incomplete scans, root collisions, changed-during-read files, or two-sided divergence.
- Writes atomic diagnostic state to `custom_autocloud_status.json`.
- Reuses the normal CAS blob store, manifest, change-number, and snapshot machinery.

## Validation

- Built the Linux `cloud_redirect.so` target successfully.
- Added and passed `custom_autocloud_tests` covering valid configuration and malicious path/root/pattern rejection.
- Ran `git diff --check`.

Windows x64 and Linux 32-bit artifact builds remain for CI/maintainer validation.