### PR TITLE
feat(playtime): push the local session into the running client

### DIFF
--- a/src/common/stats_handlers.cpp
+++ b/src/common/stats_handlers.cpp
@@ -302,7 +302,7 @@ std::optional<std::vector<uint8_t>> HandleLegacyStoreUserStats2(
 }
 
 // Observe CMsgClientGamesPlayed (EMsg 5410) for playtime session tracking.
-void ObserveGamesPlayed(const uint8_t* body, size_t bodyLen) {
+std::vector<uint32_t> ObserveGamesPlayed(const uint8_t* body, size_t bodyLen) {
     auto fields = PB::Parse(body, bodyLen);
 
     std::unordered_set<uint32_t> currentApps;
@@ -342,6 +342,7 @@ void ObserveGamesPlayed(const uint8_t* body, size_t bodyLen) {
     for (uint32_t appId : ended) {
         g_activeApps.erase(appId);
     }
+    return ended;
 }
 
 // Observe StoreUserStats2 (EMsg 5466) -- re-read native blob for new unlocks.

--- a/src/common/stats_handlers.h
+++ b/src/common/stats_handlers.h
@@ -45,8 +45,12 @@ std::optional<std::vector<uint8_t>> HandleLegacyGetUserStats(
 std::optional<std::vector<uint8_t>> HandleLegacyStoreUserStats2(
     const uint8_t* body, size_t bodyLen, uint64_t steamId);
 
-// Observe CMsgClientGamesPlayed (EMsg 5410) for playtime tracking.
-void ObserveGamesPlayed(const uint8_t* body, size_t bodyLen);
+// Observe CMsgClientGamesPlayed (EMsg 5410) for playtime tracking. Returns the
+// apps whose session just ended, so a platform with a live writer can push their
+// fresh minutes into the running client -- the cloud poller only ever queues apps
+// the CLOUD advanced, so a local session would otherwise sit unseen until Steam's
+// next natural GetLastPlayedTimes (in practice: a restart).
+std::vector<uint32_t> ObserveGamesPlayed(const uint8_t* body, size_t bodyLen);
 
 // Observe CMsgClientStoreUserStats2 (EMsg 5466) to capture achievement unlocks
 // the moment the game stores them. body = serialized message; game_id is field 1.

--- a/src/platform/linux/gamesplayed_hook.cpp
+++ b/src/platform/linux/gamesplayed_hook.cpp
@@ -1,6 +1,7 @@
 #include "gamesplayed_hook.h"
 #include "stats_handlers.h"
 #include "metadata_sync.h"
+#include "live_playtime.h"
 #include "log.h"
 
 #include <atomic>
@@ -95,7 +96,22 @@ extern "C" int GamesPlayedHook_OnSend(int cmInterface, void* msg) {
                     if (isGamesPlayed) {
                         LOG("[Stats] GamesPlayed observed (emsg=%u, %zu bytes) -> session tracking",
                             emsg, len);
-                        StatsHandlers::ObserveGamesPlayed(bytes, len);
+                        auto ended = StatsHandlers::ObserveGamesPlayed(bytes, len);
+                        // Push our own just-ended session into the running client.
+                        // The cloud poller queues exclusively what the CLOUD
+                        // advanced, so without this the fresh minutes wait for
+                        // Steam's next natural GetLastPlayedTimes -- in practice a
+                        // restart. Queue is thread-safe; the drain in BYieldingSend
+                        // applies it on the next send.
+                        if (!ended.empty() && LivePlaytime::Ready()) {
+                            PB::Writer notice =
+                                StatsHandlers::BuildLastPlayedNotificationBody(ended);
+                            if (notice.Size() > 0) {
+                                LivePlaytime::Queue(notice.Data());
+                                LOG("[Stats] Queued live playtime update for %zu local app(s)",
+                                    ended.size());
+                            }
+                        }
                     } else {
                         LOG("[Stats] StoreUserStats2 observed (emsg=%u, %zu bytes) -> capturing unlocks",
                             emsg, len);


### PR DESCRIPTION
Own playtime currently needs a client restart before it shows in the library. The live path itself works — the cloud poller queues a `LastPlayedTimes` notice and `LivePlaytime` applies it — but the poller only queues apps that the *cloud* advanced. A session on the local device is already in the local cache, so it never appears as changed and never gets pushed; it waits for Steam's next natural `GetLastPlayedTimes`.

`ObserveGamesPlayed()` already computed the list of apps whose session just ended and threw it away. This returns it, and the Linux `GamesPlayed` hook feeds those apps through the same `BuildLastPlayedNotificationBody()` + `LivePlaytime::Queue()` pair the poller uses. The drain in `BYieldingSend` applies it on the next send, so it lands immediately.

Linux-only, since `LivePlaytime` is; the Windows caller simply ignores the new return value. Independent of #175 — applies with or without it.

Verified live: `Session ended for app ...: +N min` followed immediately by `Queued live playtime update for 1 local app(s)`, and the library updated without a restart.

No unit test here — this one hangs off Steam's hooks and the captured `CUser` pointer, so it isn't meaningfully testable without a running client. The added log line is what makes it verifiable.

---

*Disclosure: this patch was written with Claude Opus 5. I reviewed it, and the build plus the live verification on my machine are mine.*
