### PR TITLE
fix(playtime): carry leftover seconds across sessions

### DIFF
--- a/src/common/stats_store.cpp
+++ b/src/common/stats_store.cpp
@@ -63,6 +63,11 @@ static uint32_t g_diskAccountId = 0;
 // Active play sessions: appId -> session start (unix time). Guarded by g_mutex.
 static std::unordered_map<uint32_t, uint32_t> g_activeSessions;
 
+// Seconds left over from the last session's minute conversion, per app, so the
+// truncation doesn't discard them. Process-local by design: persisting it would
+// mean a new blob field and merge rule for at most 59 seconds. g_mutex.
+static std::unordered_map<uint32_t, uint32_t> g_carrySeconds;
+
 // Apps reset this session; push replaces (not merges) these. g_mutex.
 static std::unordered_set<uint32_t> g_resetApps;
 
@@ -673,6 +678,7 @@ bool ResetForAccountSwitch(uint32_t newAccountId) {
     g_cloudBlobMerged.clear();
     g_dirty.clear();
     g_activeSessions.clear();
+    g_carrySeconds.clear();
     g_resetApps.clear();
     g_diskLoadPending.clear();
     g_accountBlobDirty = false;
@@ -693,6 +699,7 @@ void ResetForTesting() {
     g_cloudBlobMerged.clear();
     g_dirty.clear();
     g_activeSessions.clear();
+    g_carrySeconds.clear();
     g_resetApps.clear();
     g_diskLoadPending.clear();
     g_accountBlobDirty = false;
@@ -2214,7 +2221,13 @@ static bool EndSessionLocked(uint32_t appId) {
     // resume) must not over-count a session. Backward jumps already clamp to 0.
     const uint32_t kMaxSessionSecs = 24u * 60 * 60;
     if (elapsed > kMaxSessionSecs) elapsed = kMaxSessionSecs;
-    uint32_t minutes = elapsed / 60;
+    // Add the seconds the previous session's truncation left over and keep this
+    // one's remainder for the next. Without the carry, minute conversion discards
+    // up to 59 s per session -- a bias that is always downward and adds up over
+    // many short sessions (five 5:59 sessions counted 25 min instead of 29).
+    uint32_t total = elapsed + g_carrySeconds[appId];
+    uint32_t minutes = total / 60;
+    g_carrySeconds[appId] = total % 60;
     g_activeSessions.erase(it);
 
     // Seed first so the cloud blob's cross-device unlocks are in the record we
@@ -2268,7 +2281,10 @@ PlaytimeData GetPlaytime(uint32_t appId) {
         // over-count the in-progress session's live playtime estimate.
         const uint32_t kMaxSessionSecs = 24u * 60 * 60;
         if (elapsed > kMaxSessionSecs) elapsed = kMaxSessionSecs;
-        uint32_t minutes = elapsed / 60;
+        // Include the carry, matching EndSession, so the live estimate and the
+        // value finally stored agree instead of differing by a minute.
+        auto carry = g_carrySeconds.find(appId);
+        uint32_t minutes = (elapsed + (carry != g_carrySeconds.end() ? carry->second : 0)) / 60;
         pt.minutesForever += minutes;
         pt.minutesLastTwoWeeks += minutes;
 #ifdef _WIN32


### PR DESCRIPTION
`EndSessionLocked()` converts a session to minutes with `elapsed / 60`, which throws the remainder away. The bias is always downward and it compounds: five sessions of 5:59 are recorded as 25 minutes instead of 29.

This keeps the leftover seconds per app and adds them to the next session, so nothing is lost between sessions. `GetPlaytime()` applies the same carry, so the live in-progress estimate and the value finally stored no longer disagree by a minute.

The carry is process-local on purpose. Persisting it would mean a new field in the blob plus a merge rule, for at most 59 seconds — not worth the format change, in my view. The consequence is that a client restart still drops up to 59 s once per app, instead of once per session. It is cleared on account switch alongside `g_activeSessions`.

Found while comparing the same game across two machines: the totals differed by a minute, and the per-device buckets showed the truncation rather than a sync problem.

**No unit test.** `NowUnix()` is called directly with no seam to inject a clock, so exercising this would mean real sleeps and a fully initialised store. The arithmetic is three lines; I did not want to restructure session tracking just to test it. Happy to add a time seam if you would prefer that.

Touches the same function as #175's fix (PR #177) a few lines apart, so if that lands first this may want a trivial rebase. Independent otherwise.

---

*Disclosure: this patch was written with Claude Opus 5. I reviewed it, and the build is mine.*
